### PR TITLE
Fix build failure relating to Kafka Connect parent POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.ably.kafka.connect</groupId>
     <artifactId>kafka-connect-ably</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.0.1</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>com.github.jcustenborder.kafka.connect</groupId>
         <artifactId>kafka-connect-parent</artifactId>
-        <version>2.4.0</version>
+        <version>2.8.0-1</version>
     </parent>
 
     <licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -153,6 +153,17 @@
             <version>2.8.6</version>
         </dependency>
 
+        <!--
+          Pin reflections to 0.9.10 to prevent the following error when running DocumentationTest.java:
+
+          java.lang.NoSuchMethodError: 'java.util.Set org.reflections.Reflections.getResources(com.google.common.base.Predicate)'
+        -->
+        <dependency>
+            <groupId>org.reflections</groupId>
+            <artifactId>reflections</artifactId>
+            <version>0.9.10</version>
+        </dependency>
+
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka_${kafka.scala.version}</artifactId>


### PR DESCRIPTION
We were using a very old version of the parent POM, fixed in https://github.com/ably/kafka-connect-ably/commit/7e82474757a467f0e6c18f855ea082c79efd79cb.

Also, not sure, but https://github.com/ably/kafka-connect-ably/commit/1bc2e9318cc7da4e29453f6385bd0919e9455bf3 may have helped.

Now seeing a different build failure with Maven 3.8.1 `mvn clean package` on my local macOS machine:

```
[INFO]
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running com.ably.kafka.connect.DocumentationTest
[ERROR] Tests run: 13, Failures: 0, Errors: 13, Skipped: 0, Time elapsed: 21.802 s <<< FAILURE! - in com.ably.kafka.connect.DocumentationTest
[ERROR] rstConfigProviders  Time elapsed: 3.214 s  <<< ERROR!
java.lang.NoSuchMethodError: org.reflections.Reflections.getResources(Lcom/google/common/base/Predicate;)Ljava/util/Set;

[ERROR] validateTransformationExamples  Time elapsed: 4.977 s  <<< ERROR!
java.lang.NoSuchMethodError: org.reflections.Reflections.getResources(Lcom/google/common/base/Predicate;)Ljava/util/Set;

[ERROR] rstTransformations  Time elapsed: 6.465 s  <<< ERROR!
java.lang.NoSuchMethodError: org.reflections.Reflections.getResources(Lcom/google/common/base/Predicate;)Ljava/util/Set;

[ERROR] readmeMD  Time elapsed: 1.646 s  <<< ERROR!
java.lang.NoSuchMethodError: org.reflections.Reflections.getResources(Lcom/google/common/base/Predicate;)Ljava/util/Set;

[ERROR] rstIndex  Time elapsed: 1.702 s  <<< ERROR!
java.lang.NoSuchMethodError: org.reflections.Reflections.getResources(Lcom/google/common/base/Predicate;)Ljava/util/Set;

[ERROR] rstSinks  Time elapsed: 3.299 s  <<< ERROR!
java.lang.NoSuchMethodError: org.reflections.Reflections.getResources(Lcom/google/common/base/Predicate;)Ljava/util/Set;

[ERROR] validateConverterExamples  Time elapsed: 4.727 s  <<< ERROR!
java.lang.NoSuchMethodError: org.reflections.Reflections.getResources(Lcom/google/common/base/Predicate;)Ljava/util/Set;

[ERROR] rstConverters  Time elapsed: 6.332 s  <<< ERROR!
java.lang.NoSuchMethodError: org.reflections.Reflections.getResources(Lcom/google/common/base/Predicate;)Ljava/util/Set;

[ERROR] validateConfigProviderExamples  Time elapsed: 7.75 s  <<< ERROR!
java.lang.NoSuchMethodError: org.reflections.Reflections.getResources(Lcom/google/common/base/Predicate;)Ljava/util/Set;

[ERROR] validateSinkConnectorExamples  Time elapsed: 9.306 s  <<< ERROR!
java.lang.NoSuchMethodError: org.reflections.Reflections.getResources(Lcom/google/common/base/Predicate;)Ljava/util/Set;

[ERROR] rstSchemas  Time elapsed: 10.808 s  <<< ERROR!
java.lang.NoSuchMethodError: org.reflections.Reflections.getResources(Lcom/google/common/base/Predicate;)Ljava/util/Set;

[ERROR] rstSources  Time elapsed: 12.188 s  <<< ERROR!
java.lang.NoSuchMethodError: org.reflections.Reflections.getResources(Lcom/google/common/base/Predicate;)Ljava/util/Set;

[ERROR] validateSourceConnectorExamples  Time elapsed: 13.69 s  <<< ERROR!
java.lang.NoSuchMethodError: org.reflections.Reflections.getResources(Lcom/google/common/base/Predicate;)Ljava/util/Set;

[INFO] Running com.ably.kafka.connect.ChannelSinkTaskTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in com.ably.kafka.connect.ChannelSinkTaskTest
[INFO] Running com.ably.kafka.connect.ChannelSinkConnectorTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in com.ably.kafka.connect.ChannelSinkConnectorTest
[INFO]
[INFO] Results:
[INFO]
[ERROR] Errors:
[ERROR]   DocumentationTest>BaseDocumentationTest.before:171->BaseDocumentationTest.lambda$before$7:173 » NoSuchMethod
[ERROR]   DocumentationTest>BaseDocumentationTest.before:171->BaseDocumentationTest.lambda$before$7:173 » NoSuchMethod
[ERROR]   DocumentationTest>BaseDocumentationTest.before:171->BaseDocumentationTest.lambda$before$7:173 » NoSuchMethod
[ERROR]   DocumentationTest>BaseDocumentationTest.before:171->BaseDocumentationTest.lambda$before$7:173 » NoSuchMethod
[ERROR]   DocumentationTest>BaseDocumentationTest.before:171->BaseDocumentationTest.lambda$before$7:173 » NoSuchMethod
[ERROR]   DocumentationTest>BaseDocumentationTest.before:171->BaseDocumentationTest.lambda$before$7:173 » NoSuchMethod
[ERROR]   DocumentationTest>BaseDocumentationTest.before:171->BaseDocumentationTest.lambda$before$7:173 » NoSuchMethod
[ERROR]   DocumentationTest>BaseDocumentationTest.before:171->BaseDocumentationTest.lambda$before$7:173 » NoSuchMethod
[ERROR]   DocumentationTest>BaseDocumentationTest.before:171->BaseDocumentationTest.lambda$before$7:173 » NoSuchMethod
[ERROR]   DocumentationTest>BaseDocumentationTest.before:171->BaseDocumentationTest.lambda$before$7:173 » NoSuchMethod
[ERROR]   DocumentationTest>BaseDocumentationTest.before:171->BaseDocumentationTest.lambda$before$7:173 » NoSuchMethod
[ERROR]   DocumentationTest>BaseDocumentationTest.before:171->BaseDocumentationTest.lambda$before$7:173 » NoSuchMethod
[ERROR]   DocumentationTest>BaseDocumentationTest.before:171->BaseDocumentationTest.lambda$before$7:173 » NoSuchMethod
[INFO]
[ERROR] Tests run: 15, Failures: 0, Errors: 13, Skipped: 0
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:45 min
[INFO] Finished at: 2021-07-30T15:30:59+01:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:2.22.2:test (default-test) on project kafka-connect-ably: There are test failures.
[ERROR]
[ERROR] Please refer to /Users/quintinwillison/code/ably/kafka-connect-ably/target/surefire-reports for the individual test results.
[ERROR] Please refer to dump files (if any exist) [date].dump, [date]-jvmRun[N].dump and [date].dumpstream.
[ERROR] -> [Help 1]
[ERROR]
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR]
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoFailureException
```

Which looks like we're back in the domain of code, rather than dependencies.