### PR TITLE
Set 'kafka-connect-ably' in the Ably-Agent header

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -147,7 +147,7 @@
         <dependency>
             <groupId>io.ably</groupId>
             <artifactId>ably-java</artifactId>
-            <version>1.2.3</version>
+            <version>1.2.9</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/com/ably/kafka/connect/ChannelSinkConnectorConfig.java
+++ b/src/main/java/com/ably/kafka/connect/ChannelSinkConnectorConfig.java
@@ -199,6 +199,14 @@ public class ChannelSinkConnectorConfig extends AbstractConfig {
   private static final String CLIENT_CHANNEL_PARAMS_DOC = "Additional channel parameters used to configure the " +
     "behaviour of the channel. This should be specified in the form \"key1=value1,key2=value2,...\".";
 
+  // The name of the extra agent identifier to add to the Ably-Agent header to
+  // identify this client as using the Ably Kafka Connector.
+  private static final String ABLY_AGENT_HEADER_NAME = "kafka-connect-ably";
+
+  // The default Ably-Agent version to use when the library version can't be
+  // determined (for example in the tests).
+  private static final String ABLY_AGENT_DEFAULT_VERSION = "0.0.0";
+
   private static final Logger logger = LoggerFactory.getLogger(ChannelSinkConnectorConfig.class);
 
   public final String channelName;
@@ -279,6 +287,14 @@ public class ChannelSinkConnectorConfig extends AbstractConfig {
     opts.transportParams = convertTransportParams(getList(CLIENT_TRANSPORT_PARAMS));
     opts.asyncHttpThreadpoolSize = getInt(CLIENT_ASYNC_HTTP_THREADPOOL_SIZE);
     opts.pushFullWait = getBoolean(CLIENT_PUSH_FULL_WAIT);
+
+    // Add the library version to the list of Ably-Agent identifiers.
+    String version = getClass().getPackage().getImplementationVersion();
+    if(version == null) {
+      version = ABLY_AGENT_DEFAULT_VERSION;
+    }
+    opts.agents = Map.of(ABLY_AGENT_HEADER_NAME, version);
+
     return opts;
   }
 

--- a/src/test/java/com/ably/kafka/connect/AblyHelpers.java
+++ b/src/test/java/com/ably/kafka/connect/AblyHelpers.java
@@ -70,7 +70,7 @@ public class AblyHelpers {
      * spec in the body to /apps.
      */
     public static AppSpec createTestApp() throws AblyException {
-        ClientOptions opts = new ClientOptions("");
+        ClientOptions opts = new ClientOptions("a.b:c");
         opts.environment = TEST_ENVIRONMENT;
         AblyRest ably = new AblyRest(opts);
 


### PR DESCRIPTION
So we can track the usage of the connector.

`kafka-connect-ably` has been added to agents.json in https://github.com/ably/ably-common/pull/123.