### PR TITLE
Caught exception and printed stack trace instead of throwing it to resume task

### DIFF
--- a/src/main/java/com/ably/kafka/connect/ChannelSinkTask.java
+++ b/src/main/java/com/ably/kafka/connect/ChannelSinkTask.java
@@ -123,9 +123,8 @@ public class ChannelSinkTask extends SinkTask {
 
                 channel.publish(message);
             } catch (AblyException e) {
-                // The ably client should attempt retries itself, so if we do have to handle an exception here,
-                // we can assume that it is not retryably.
-                throw new ConnectException("ably client failed to publish", e);
+            
+                e.printStackTrace();
             }
         }
     }

--- a/src/main/java/com/ably/kafka/connect/ChannelSinkTask.java
+++ b/src/main/java/com/ably/kafka/connect/ChannelSinkTask.java
@@ -25,6 +25,7 @@ import com.github.jcustenborder.kafka.connect.utils.VersionUtil;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.connect.errors.ConnectException;
+import org.apache.kafka.connect.errors.RetriableException;
 import org.apache.kafka.connect.header.Header;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.apache.kafka.connect.sink.SinkTask;
@@ -123,7 +124,12 @@ public class ChannelSinkTask extends SinkTask {
 
                 channel.publish(message);
             } catch (AblyException e) {
-                logger.error("Failed to publish message", e);
+                if(ably.options.queueMessages){
+                    logger.error("Failed to publish message", e);
+                }else{
+                    throw new RetriableException(e.getMessage());
+                }
+                
             }
         }
     }

--- a/src/main/java/com/ably/kafka/connect/ChannelSinkTask.java
+++ b/src/main/java/com/ably/kafka/connect/ChannelSinkTask.java
@@ -127,7 +127,7 @@ public class ChannelSinkTask extends SinkTask {
                 if (ably.options.queueMessages) {
                     logger.error("Failed to publish message", e);
                 } else {
-                    throw new RetriableException(e.getMessage());
+                    throw new RetriableException("Failed to publish to Ably when queueMessages is disabled.",e);
                 }
             }
         }

--- a/src/main/java/com/ably/kafka/connect/ChannelSinkTask.java
+++ b/src/main/java/com/ably/kafka/connect/ChannelSinkTask.java
@@ -124,12 +124,11 @@ public class ChannelSinkTask extends SinkTask {
 
                 channel.publish(message);
             } catch (AblyException e) {
-                if(ably.options.queueMessages){
+                if (ably.options.queueMessages) {
                     logger.error("Failed to publish message", e);
-                }else{
+                } else {
                     throw new RetriableException(e.getMessage());
                 }
-                
             }
         }
     }

--- a/src/main/java/com/ably/kafka/connect/ChannelSinkTask.java
+++ b/src/main/java/com/ably/kafka/connect/ChannelSinkTask.java
@@ -123,8 +123,7 @@ public class ChannelSinkTask extends SinkTask {
 
                 channel.publish(message);
             } catch (AblyException e) {
-            
-                e.printStackTrace();
+                logger.error("Failed to publish message", e);
             }
         }
     }


### PR DESCRIPTION
This PR fixes an issue where a failure of message delivery would cause the whole task to halt.

Changes
* If queueMessages is enabled and if an AblyException occurs, I log error
* If queueMessages is not enabled I thrown RetriableException (See `put` https://kafka.apache.org/11/javadoc/org/apache/kafka/connect/sink/SinkTask.html for why I did that)