### PR TITLE
Multiple channels

### DIFF
--- a/src/main/java/com/ably/kafka/connect/ChannelConfig.java
+++ b/src/main/java/com/ably/kafka/connect/ChannelConfig.java
@@ -2,6 +2,6 @@ package com.ably.kafka.connect;
 
 import org.apache.kafka.connect.sink.SinkRecord;
 
-public interface ChannelSinkChannelConfig {
+public interface ChannelConfig {
     String channelName(SinkRecord record);
 }

--- a/src/main/java/com/ably/kafka/connect/ChannelSinkChannelConfig.java
+++ b/src/main/java/com/ably/kafka/connect/ChannelSinkChannelConfig.java
@@ -1,0 +1,7 @@
+package com.ably.kafka.connect;
+
+import org.apache.kafka.connect.sink.SinkRecord;
+
+public interface ChannelSinkChannelConfig {
+    String channelName(SinkRecord record);
+}

--- a/src/main/java/com/ably/kafka/connect/ChannelSinkConnectorConfig.java
+++ b/src/main/java/com/ably/kafka/connect/ChannelSinkConnectorConfig.java
@@ -27,8 +27,6 @@ import io.ably.lib.http.HttpAuth;
 import io.ably.lib.rest.Auth.TokenParams;
 import io.ably.lib.transport.Defaults;
 import io.ably.lib.types.AblyException;
-import io.ably.lib.types.ChannelMode;
-import io.ably.lib.types.ChannelOptions;
 import io.ably.lib.types.ClientOptions;
 import io.ably.lib.types.Param;
 import io.ably.lib.types.ProxyOptions;
@@ -39,7 +37,6 @@ import com.github.jcustenborder.kafka.connect.utils.config.recommenders.Recommen
 import com.github.jcustenborder.kafka.connect.utils.config.validators.Validators;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -203,7 +200,7 @@ public class ChannelSinkConnectorConfig extends AbstractConfig {
   private static final Logger logger = LoggerFactory.getLogger(ChannelSinkConnectorConfig.class);
 
   public final ClientOptions clientOptions;
-  public final ChannelSinkChannelConfig channelConfig;
+  public final ChannelConfig channelConfig;
 
   private static class ConfigException extends Exception {
     private static final long serialVersionUID = 6225540388729441285L;
@@ -229,8 +226,8 @@ public class ChannelSinkConnectorConfig extends AbstractConfig {
     clientOptions = clientOpts;
 
     final Object channelConfigInstance = Utils.newInstance(getClass(CHANNEL_SINK_CONFIG_CLASS));
-    if (channelConfigInstance instanceof ChannelSinkChannelConfig) {
-      channelConfig = (ChannelSinkChannelConfig) channelConfigInstance;
+    if (channelConfigInstance instanceof ChannelConfig) {
+      channelConfig = (ChannelConfig) channelConfigInstance;
     }else {
       channelConfig = null;
       logger.error("Please provide correct class name for channel sink config class");
@@ -558,7 +555,7 @@ public class ChannelSinkConnectorConfig extends AbstractConfig {
          ConfigKeyBuilder.of(CHANNEL_SINK_CONFIG_CLASS, Type.CLASS)
                  .documentation(CHANNEL_SINK_CONFIG_CLASS_DOC)
                  .importance(Importance.HIGH)
-                 .defaultValue(DefaultChannelSinkChannelConfig.class)
+                 .defaultValue(DefaultChannelConfig.class)
                  .build()
             ) ;
   }

--- a/src/main/java/com/ably/kafka/connect/ChannelSinkTask.java
+++ b/src/main/java/com/ably/kafka/connect/ChannelSinkTask.java
@@ -26,6 +26,7 @@ import io.ably.lib.util.JsonUtils;
 import io.ably.lib.util.JsonUtils.JsonUtilsObject;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.errors.RetriableException;
 import org.apache.kafka.connect.header.Header;
 import org.apache.kafka.connect.sink.SinkRecord;
@@ -95,6 +96,10 @@ public class ChannelSinkTask extends SinkTask {
 
     @Override
     public void put(Collection<SinkRecord> records) {
+        if (ably == null) {
+            // Cannot retry for this case
+            throw new ConnectException("ably client is uninitialized");
+        }
         for (SinkRecord r : records) {
             // TODO: add configuration to change the event name
             try {

--- a/src/main/java/com/ably/kafka/connect/ChannelSinkTask.java
+++ b/src/main/java/com/ably/kafka/connect/ChannelSinkTask.java
@@ -45,15 +45,14 @@ public class ChannelSinkTask extends SinkTask {
     private static final Logger logger = LoggerFactory.getLogger(ChannelSinkTask.class);
     private static final String[] severities = new String[]{"", "", "VERBOSE", "DEBUG", "INFO", "WARN", "ERROR", "ASSERT"};
 
-    ChannelSinkConnectorConfig config;
-    AblyRealtime ably;
-    Channel channel;
+    private AblyRealtime ably;
+    private Channel channel;
 
     @Override
     public void start(Map<String, String> settings) {
         logger.info("Starting Ably channel Sink task");
 
-        config = new ChannelSinkConnectorConfig(settings);
+        ChannelSinkConnectorConfig config = new ChannelSinkConnectorConfig(settings);
 
         if (config.clientOptions == null) {
             logger.error("Ably client options were not initialized due to invalid configuration.");

--- a/src/main/java/com/ably/kafka/connect/ChannelSinkTask.java
+++ b/src/main/java/com/ably/kafka/connect/ChannelSinkTask.java
@@ -43,7 +43,7 @@ public class ChannelSinkTask extends SinkTask {
     private static final String[] severities = new String[]{"", "", "VERBOSE", "DEBUG", "INFO", "WARN", "ERROR", "ASSERT"};
 
     private AblyRealtime ably;
-    private ChannelSinkChannelConfig channelConfig;
+    private ChannelConfig channelConfig;
 
     @Override
     public void start(Map<String, String> settings) {

--- a/src/main/java/com/ably/kafka/connect/ChannelSinkTask.java
+++ b/src/main/java/com/ably/kafka/connect/ChannelSinkTask.java
@@ -100,18 +100,18 @@ public class ChannelSinkTask extends SinkTask {
             // Cannot retry for this case
             throw new ConnectException("ably client is uninitialized");
         }
-        for (SinkRecord r : records) {
+        for (SinkRecord sinkRecord : records) {
             // TODO: add configuration to change the event name
             try {
-                Message message = new Message("sink", r.value());
-                message.id = String.format("%d:%d:%d", r.topic().hashCode(), r.kafkaPartition(), r.kafkaOffset());
+                Message message = new Message("sink", sinkRecord.value());
+                message.id = String.format("%d:%d:%d", sinkRecord.topic().hashCode(), sinkRecord.kafkaPartition(), sinkRecord.kafkaOffset());
 
-                JsonUtilsObject kafkaExtras = createKafkaExtras(r);
+                JsonUtilsObject kafkaExtras = createKafkaExtras(sinkRecord);
                 if(kafkaExtras.toJson().size() > 0 ) {
                     message.extras = new MessageExtras(JsonUtils.object().add("kafka", kafkaExtras).toJson());
                 }
 
-                final  Channel channel = ably.channels.get(r.topic());
+                final  Channel channel = ably.channels.get(sinkRecord.topic());
                 channel.publish(message);
             } catch (AblyException e) {
                 if (ably.options.queueMessages) {

--- a/src/main/java/com/ably/kafka/connect/DefaultChannelConfig.java
+++ b/src/main/java/com/ably/kafka/connect/DefaultChannelConfig.java
@@ -3,7 +3,7 @@ package com.ably.kafka.connect;
 
 import org.apache.kafka.connect.sink.SinkRecord;
 
-public class DefaultChannelSinkChannelConfig implements ChannelSinkChannelConfig {
+public class DefaultChannelConfig implements ChannelConfig {
     @Override
     public String channelName(SinkRecord record) {
         return record.topic();

--- a/src/main/java/com/ably/kafka/connect/DefaultChannelSinkChannelConfig.java
+++ b/src/main/java/com/ably/kafka/connect/DefaultChannelSinkChannelConfig.java
@@ -1,0 +1,11 @@
+package com.ably.kafka.connect;
+
+
+import org.apache.kafka.connect.sink.SinkRecord;
+
+public class DefaultChannelSinkChannelConfig implements ChannelSinkChannelConfig {
+    @Override
+    public String channelName(SinkRecord record) {
+        return record.topic();
+    }
+}


### PR DESCRIPTION
Our current kafka-connect-ably currently sinks messages to a single channel and that channel is configured when the application is deployed. @lmars  mentioned that this was done like this because it was as a proof of concept.

Recently  we had a meeting with one of our customers who was interested in using this product. Their use case showed that they want to use channels dynamically (channel per customer on their case). 

Currently the channel, channel options, cipher options (everything related to a channel) is provided as configuration property. Instead we want to dynamically get (or create) a channel and channel related options based on a Kafka record. 

(Based on what we will create a channel is a subject for discussion. I initially substitute a 'topic' to create a channel but that is likely to change.) I would like to get some advice on how best would be to model such a mapping. Ideally we are able to amend connect configuration so that we could provide some rules on how to create a channel and channel configuration. For example should we / can we provide a field from SinkRecord as a channel? Better if we can create an interface that will provide a channel with its corresponding options based on the sink record. 