### PR TITLE
Refactor to channel map interface

### DIFF
--- a/src/main/java/com/ably/kafka/connect/ChannelSinkMapping.java
+++ b/src/main/java/com/ably/kafka/connect/ChannelSinkMapping.java
@@ -15,5 +15,5 @@ public interface ChannelSinkMapping {
      * @param ablyRealtime AblyRealtime instance.
      * @return The channel.
      */
-    Channel getChannel(@Nonnull SinkRecord sinkRecord,@Nonnull AblyRealtime ablyRealtime) throws AblyException;
+    Channel getChannel(@Nonnull SinkRecord sinkRecord,@Nonnull AblyRealtime ablyRealtime) throws AblyException, ChannelSinkConnectorConfig.ConfigException;
 }

--- a/src/main/java/com/ably/kafka/connect/ChannelSinkMapping.java
+++ b/src/main/java/com/ably/kafka/connect/ChannelSinkMapping.java
@@ -1,0 +1,15 @@
+package com.ably.kafka.connect;
+
+import org.apache.kafka.connect.sink.SinkRecord;
+
+import java.nio.channels.Channel;
+
+public interface ChannelSinkMapping {
+    /**
+     * Returns the channel for the given sink record.
+     *
+     * @param sinkRecord The sink record.
+     * @return The channel.
+     */
+    Channel getChannel(SinkRecord sinkRecord);
+}

--- a/src/main/java/com/ably/kafka/connect/ChannelSinkMapping.java
+++ b/src/main/java/com/ably/kafka/connect/ChannelSinkMapping.java
@@ -5,6 +5,8 @@ import io.ably.lib.realtime.Channel;
 import io.ably.lib.types.AblyException;
 import org.apache.kafka.connect.sink.SinkRecord;
 
+import javax.annotation.Nonnull;
+
 public interface ChannelSinkMapping {
     /**
      * Returns the channel for the given sink record.
@@ -13,5 +15,5 @@ public interface ChannelSinkMapping {
      * @param ablyRealtime AblyRealtime instance.
      * @return The channel.
      */
-    Channel getChannel(SinkRecord sinkRecord, AblyRealtime ablyRealtime) throws AblyException;
+    Channel getChannel(@Nonnull SinkRecord sinkRecord,@Nonnull AblyRealtime ablyRealtime) throws AblyException;
 }

--- a/src/main/java/com/ably/kafka/connect/ChannelSinkMapping.java
+++ b/src/main/java/com/ably/kafka/connect/ChannelSinkMapping.java
@@ -1,5 +1,6 @@
 package com.ably.kafka.connect;
 
+import io.ably.lib.realtime.AblyRealtime;
 import org.apache.kafka.connect.sink.SinkRecord;
 
 import java.nio.channels.Channel;
@@ -9,7 +10,8 @@ public interface ChannelSinkMapping {
      * Returns the channel for the given sink record.
      *
      * @param sinkRecord The sink record.
+     * @param ablyRealtime AblyRealtime instance.
      * @return The channel.
      */
-    Channel getChannel(SinkRecord sinkRecord);
+    Channel getChannel(SinkRecord sinkRecord, AblyRealtime ablyRealtime);
 }

--- a/src/main/java/com/ably/kafka/connect/ChannelSinkMapping.java
+++ b/src/main/java/com/ably/kafka/connect/ChannelSinkMapping.java
@@ -1,9 +1,9 @@
 package com.ably.kafka.connect;
 
 import io.ably.lib.realtime.AblyRealtime;
+import io.ably.lib.realtime.Channel;
+import io.ably.lib.types.AblyException;
 import org.apache.kafka.connect.sink.SinkRecord;
-
-import java.nio.channels.Channel;
 
 public interface ChannelSinkMapping {
     /**
@@ -13,5 +13,5 @@ public interface ChannelSinkMapping {
      * @param ablyRealtime AblyRealtime instance.
      * @return The channel.
      */
-    Channel getChannel(SinkRecord sinkRecord, AblyRealtime ablyRealtime);
+    Channel getChannel(SinkRecord sinkRecord, AblyRealtime ablyRealtime) throws AblyException;
 }

--- a/src/main/java/com/ably/kafka/connect/ChannelSinkTask.java
+++ b/src/main/java/com/ably/kafka/connect/ChannelSinkTask.java
@@ -104,7 +104,7 @@ public class ChannelSinkTask extends SinkTask {
             throw new ConnectException("ably client is uninitialized");
         }
 
-        for (SinkRecord record : records) {
+        for (final SinkRecord record : records) {
             // TODO: add configuration to change the event name
             try {
                 Message message = new Message("sink", record.value());

--- a/src/main/java/com/ably/kafka/connect/ChannelSinkTask.java
+++ b/src/main/java/com/ably/kafka/connect/ChannelSinkTask.java
@@ -42,8 +42,7 @@ public class ChannelSinkTask extends SinkTask {
     private static final Logger logger = LoggerFactory.getLogger(ChannelSinkTask.class);
     private static final String[] severities = new String[]{"", "", "VERBOSE", "DEBUG", "INFO", "WARN", "ERROR", "ASSERT"};
 
-    ChannelSinkConnectorConfig config;
-    AblyRealtime ably;
+    private AblyRealtime ably;
 
     private ChannelSinkMapping channelSinkMapping;
 
@@ -51,7 +50,7 @@ public class ChannelSinkTask extends SinkTask {
     public void start(Map<String, String> settings) {
         logger.info("Starting Ably channel Sink task");
 
-        config = new ChannelSinkConnectorConfig(settings);
+        final ChannelSinkConnectorConfig config = new ChannelSinkConnectorConfig(settings);
         channelSinkMapping = new DefaultChannelSinkMapping(config);
 
         if (config.clientOptions == null) {

--- a/src/main/java/com/ably/kafka/connect/DefaultChannelSinkMapping.java
+++ b/src/main/java/com/ably/kafka/connect/DefaultChannelSinkMapping.java
@@ -5,14 +5,16 @@ import io.ably.lib.realtime.Channel;
 import io.ably.lib.types.AblyException;
 import org.apache.kafka.connect.sink.SinkRecord;
 
+import javax.annotation.Nonnull;
+
 public class DefaultChannelSinkMapping implements ChannelSinkMapping {
     private final ChannelSinkConnectorConfig sinkConnectorConfig;
-    public DefaultChannelSinkMapping(ChannelSinkConnectorConfig config) {
+    public DefaultChannelSinkMapping(@Nonnull ChannelSinkConnectorConfig config) {
         sinkConnectorConfig = config;
     }
 
     @Override
-    public Channel getChannel(SinkRecord sinkRecord, AblyRealtime ablyRealtime) throws AblyException {
+    public Channel getChannel(@Nonnull SinkRecord sinkRecord, @Nonnull AblyRealtime ablyRealtime) throws AblyException {
         return ablyRealtime.channels.get(sinkConnectorConfig.channelName, sinkConnectorConfig.channelOptions);
     }
 }

--- a/src/main/java/com/ably/kafka/connect/DefaultChannelSinkMapping.java
+++ b/src/main/java/com/ably/kafka/connect/DefaultChannelSinkMapping.java
@@ -1,12 +1,13 @@
 package com.ably.kafka.connect;
 
+import io.ably.lib.realtime.AblyRealtime;
 import org.apache.kafka.connect.sink.SinkRecord;
 
 import java.nio.channels.Channel;
 
 public class DefaultChannelSinkMapping implements ChannelSinkMapping {
     @Override
-    public Channel getChannel(SinkRecord sinkRecord) {
+    public Channel getChannel(SinkRecord sinkRecord, AblyRealtime ablyRealtime) {
         return null;
     }
 }

--- a/src/main/java/com/ably/kafka/connect/DefaultChannelSinkMapping.java
+++ b/src/main/java/com/ably/kafka/connect/DefaultChannelSinkMapping.java
@@ -1,0 +1,12 @@
+package com.ably.kafka.connect;
+
+import org.apache.kafka.connect.sink.SinkRecord;
+
+import java.nio.channels.Channel;
+
+public class DefaultChannelSinkMapping implements ChannelSinkMapping {
+    @Override
+    public Channel getChannel(SinkRecord sinkRecord) {
+        return null;
+    }
+}

--- a/src/main/java/com/ably/kafka/connect/DefaultChannelSinkMapping.java
+++ b/src/main/java/com/ably/kafka/connect/DefaultChannelSinkMapping.java
@@ -1,13 +1,18 @@
 package com.ably.kafka.connect;
 
 import io.ably.lib.realtime.AblyRealtime;
+import io.ably.lib.realtime.Channel;
+import io.ably.lib.types.AblyException;
 import org.apache.kafka.connect.sink.SinkRecord;
 
-import java.nio.channels.Channel;
-
 public class DefaultChannelSinkMapping implements ChannelSinkMapping {
+    private final ChannelSinkConnectorConfig sinkConnectorConfig;
+    public DefaultChannelSinkMapping(ChannelSinkConnectorConfig config) {
+        sinkConnectorConfig = config;
+    }
+
     @Override
-    public Channel getChannel(SinkRecord sinkRecord, AblyRealtime ablyRealtime) {
-        return null;
+    public Channel getChannel(SinkRecord sinkRecord, AblyRealtime ablyRealtime) throws AblyException {
+        return ablyRealtime.channels.get(sinkConnectorConfig.channelName, sinkConnectorConfig.channelOptions);
     }
 }

--- a/src/test/java/com/ably/kafka/connect/DefaultChannelSinkMappingTest.java
+++ b/src/test/java/com/ably/kafka/connect/DefaultChannelSinkMappingTest.java
@@ -36,7 +36,7 @@ class DefaultChannelSinkMappingTest {
     }
 
     @Test
-    void testGetChannel_static_name_is_exactly_the_same() throws AblyException {
+    void testGetChannel_static_name_is_exactly_the_same() throws AblyException, ChannelSinkConnectorConfig.ConfigException {
         SinkRecord record = new SinkRecord("topic", 0, null, null, null, null, 0);
         final Channel channel = SUT.getChannel(record, ablyRealtime);
         assertEquals(STATIC_CHANNEL_NAME, channel.name);

--- a/src/test/java/com/ably/kafka/connect/DefaultChannelSinkMappingTest.java
+++ b/src/test/java/com/ably/kafka/connect/DefaultChannelSinkMappingTest.java
@@ -13,7 +13,7 @@ import java.util.Map;
 import static org.junit.jupiter.api.Assertions.*;
 
 class DefaultChannelSinkMappingTest {
-    private DefaultChannelSinkMapping SUT;
+    private DefaultChannelSinkMapping defaultChannelSinkMapping;
 
     //dependencies
     private static final String STATIC_CHANNEL_NAME = "sink-channel";
@@ -22,7 +22,7 @@ class DefaultChannelSinkMappingTest {
 
     @BeforeEach
     void setUp() throws AblyException {
-        SUT = new DefaultChannelSinkMapping(STATIC_CHANNEL_CONFIG);
+        defaultChannelSinkMapping = new DefaultChannelSinkMapping(STATIC_CHANNEL_CONFIG);
         ablyRealtime = new AblyRealtime(STATIC_CHANNEL_CONFIG.clientOptions);
     }
 
@@ -34,7 +34,7 @@ class DefaultChannelSinkMappingTest {
     @Test
     void testGetChannel_static_name_is_exactly_the_same() throws AblyException, ChannelSinkConnectorConfig.ConfigException {
         SinkRecord record = new SinkRecord("topic", 0, null, null, null, null, 0);
-        final Channel channel = SUT.getChannel(record, ablyRealtime);
+        final Channel channel = defaultChannelSinkMapping.getChannel(record, ablyRealtime);
         assertEquals(STATIC_CHANNEL_NAME, channel.name);
     }
 }

--- a/src/test/java/com/ably/kafka/connect/DefaultChannelSinkMappingTest.java
+++ b/src/test/java/com/ably/kafka/connect/DefaultChannelSinkMappingTest.java
@@ -1,0 +1,52 @@
+package com.ably.kafka.connect;
+
+import io.ably.lib.realtime.AblyRealtime;
+import io.ably.lib.realtime.Channel;
+import io.ably.lib.types.AblyException;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class DefaultChannelSinkMappingTest {
+    private DefaultChannelSinkMapping SUT;
+
+    //dependencies
+    private static final String STATIC_CHANNEL_NAME = "sink-channel";
+    private static ChannelSinkConnectorConfig STATIC_CHANNEL_CONFIG = new ChannelSinkConnectorConfig(Map.of("channel", STATIC_CHANNEL_NAME, "client.key", "test-key", "client.id", "test-id"));
+    private AblyRealtime ablyRealtime;
+
+    @BeforeEach
+    void setUp() {
+        SUT = new DefaultChannelSinkMapping(STATIC_CHANNEL_CONFIG);
+        try {
+            ablyRealtime = new AblyRealtime(STATIC_CHANNEL_CONFIG.clientOptions);
+        } catch (AblyException e) {
+            e.printStackTrace();
+        }
+    }
+
+    @AfterEach
+    void tearDown() {
+        ablyRealtime.close();
+    }
+
+    @Test
+    void testGetChannel_static_name_is_exactly_the_same() throws AblyException {
+        SinkRecord record = new SinkRecord("topic", 0, null, null, null, null, 0);
+        final Channel channel = SUT.getChannel(record, ablyRealtime);
+        assertEquals(STATIC_CHANNEL_NAME, channel.name);
+    }
+
+    //unfortunately there is not a way to access to options inside Channel so that we can test them agains the config
+   /* @Test
+    void testGetChannel_given_static_channel_options_exaclty_the_same() throws AblyException {
+        SinkRecord record = new SinkRecord("topic", 0, null, null, null, null, 0);
+        final Channel channel = SUT.getChannel(record, ablyRealtime);
+        assertEquals(connectorConfig.channelOptions, channel.options);
+    }*/
+}

--- a/src/test/java/com/ably/kafka/connect/DefaultChannelSinkMappingTest.java
+++ b/src/test/java/com/ably/kafka/connect/DefaultChannelSinkMappingTest.java
@@ -41,12 +41,4 @@ class DefaultChannelSinkMappingTest {
         final Channel channel = SUT.getChannel(record, ablyRealtime);
         assertEquals(STATIC_CHANNEL_NAME, channel.name);
     }
-
-    //unfortunately there is not a way to access to options inside Channel so that we can test them agains the config
-   /* @Test
-    void testGetChannel_given_static_channel_options_exaclty_the_same() throws AblyException {
-        SinkRecord record = new SinkRecord("topic", 0, null, null, null, null, 0);
-        final Channel channel = SUT.getChannel(record, ablyRealtime);
-        assertEquals(connectorConfig.channelOptions, channel.options);
-    }*/
 }

--- a/src/test/java/com/ably/kafka/connect/DefaultChannelSinkMappingTest.java
+++ b/src/test/java/com/ably/kafka/connect/DefaultChannelSinkMappingTest.java
@@ -21,13 +21,9 @@ class DefaultChannelSinkMappingTest {
     private AblyRealtime ablyRealtime;
 
     @BeforeEach
-    void setUp() {
+    void setUp() throws AblyException {
         SUT = new DefaultChannelSinkMapping(STATIC_CHANNEL_CONFIG);
-        try {
-            ablyRealtime = new AblyRealtime(STATIC_CHANNEL_CONFIG.clientOptions);
-        } catch (AblyException e) {
-            e.printStackTrace();
-        }
+        ablyRealtime = new AblyRealtime(STATIC_CHANNEL_CONFIG.clientOptions);
     }
 
     @AfterEach

--- a/src/test/java/com/ably/kafka/connect/DefaultChannelSinkMappingTest.java
+++ b/src/test/java/com/ably/kafka/connect/DefaultChannelSinkMappingTest.java
@@ -10,7 +10,8 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 
 class DefaultChannelSinkMappingTest {
     private DefaultChannelSinkMapping defaultChannelSinkMapping;


### PR DESCRIPTION
This pull request aims to refactor the way sink record maps to Ably channels. Record to channel mapping is currently based on a static configuration and as design imposes, it can only allow a single channel. I have refactored how the channel is provided to a 'sink task'  so that it is possible now to provide an Ably channel-per record. However because of the current implementation, the functionality will not change and we will still have a single channel throughout app lifecycle. This is just a ground work that allows us to provide a channel per record more easily. Following PRs should make the aim of this one more clear. I will try to summarise work done below
* Added an interface to map between `SinkRecord` and an Ably `Channel` so that channel mapping happens through a common interface
* Provided a default implementation which currently uses the global config to get a channel
* Used the default implementation in `ChannelSinkTask`
* Did some code cleanup on `ChannelSinkTask` 

Note to reviewers: I tried to create a unit test for DefaultChannelSinkMapping, but I found it quite difficult to mock `Channels` in `AblyRealtime` as it's defined as a final instance variable and is accessed as so. I wonder if someone has done successful mock before @KacperKluka 🤔 

Also see: https://github.com/ably/kafka-connect-ably/pull/38#issuecomment-1048706239