### PR TITLE
Make message name configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,8 @@ The advanced properties that can be configured for the connector are:
 
 | Property | Description | Type | Default |
 | -------- | ----------- | ---- | ------- |
-| client.async.http.threadpool.size | The size of the asyncHttp threadpool. | *Integer* | 64 |
+| message.name | Ably message name to publish. | *String* |  |
+| client.async.http.threadpool.size | The size of the asyncHttp threadpool. | *Integer* |  |
 | client.auto.connect | Sets whether the initiation of a connection when the library is instanced is automatic or not. | *Boolean* | True |
 | client.channel.cipher.key | Sets whether encryption is enforced for the channel when not null. Also specifies encryption-related parameters such as algorithm, chaining mode, key length and key. | *String* ||
 | client.channel.params | Specify additional channel parameters in the format `key1=value1,key2=value2`. | *List* ||

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ The advanced properties that can be configured for the connector are:
 | Property | Description | Type | Default |
 | -------- | ----------- | ---- | ------- |
 | message.name | Ably message name to publish. | *String* |  |
-| client.async.http.threadpool.size | The size of the asyncHttp threadpool. | *Integer* |  |
+| client.async.http.threadpool.size | The size of the asyncHttp threadpool. | *Integer* | 64 |
 | client.auto.connect | Sets whether the initiation of a connection when the library is instanced is automatic or not. | *Boolean* | True |
 | client.channel.cipher.key | Sets whether encryption is enforced for the channel when not null. Also specifies encryption-related parameters such as algorithm, chaining mode, key length and key. | *String* ||
 | client.channel.params | Specify additional channel parameters in the format `key1=value1,key2=value2`. | *List* ||

--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ value with `key1=value1_#{topic},key2=value2_#{key}` in your configuration,
 and publish a message to "topic1" with key "key1", the `client.channel.params`  will be configured with `key1=value1_topic1,key2=value2_key1`
 * `message.name`
   * For example, if you define a `message.name` value with `message_#{topic}_#{key}` in your configuration, and publish a message to "topic1" with key "key1", the `message.name` will be configured with `message_topic1_key1`
+
 ## Contributing
 
 For guidance on how to contribute to this project, see [CONTRIBUTING.md](CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ Configurations that are supported:
   * For this configuration individual channel parameters can be configured. For example, if you define a `client.channel.params` 
 value with `key1=value1_#{topic},key2=value2_#{key}` in your configuration,
 and publish a message to "topic1" with key "key1", the `client.channel.params`  will be configured with `key1=value1_topic1,key2=value2_key1`
-*`message.name`
+* `message.name`
   * For example, if you define a `message.name` value with `message_#{topic}_#{key}` in your configuration, and publish a message to "topic1" with key "key1", the `message.name` will be configured with `message_topic1_key1`
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -168,6 +168,8 @@ Configurations that are supported:
   * For this configuration individual channel parameters can be configured. For example, if you define a `client.channel.params` 
 value with `key1=value1_#{topic},key2=value2_#{key}` in your configuration,
 and publish a message to "topic1" with key "key1", the `client.channel.params`  will be configured with `key1=value1_topic1,key2=value2_key1`
+*`message.name`
+  * For example, if you define a `message.name` value with `message_#{topic}_#{key}` in your configuration, and publish a message to "topic1" with key "key1", the `message.name` will be configured with `message_topic1_key1`
 ## Contributing
 
 For guidance on how to contribute to this project, see [CONTRIBUTING.md](CONTRIBUTING.md).

--- a/src/main/java/com/ably/kafka/connect/ChannelSinkConnectorConfig.java
+++ b/src/main/java/com/ably/kafka/connect/ChannelSinkConnectorConfig.java
@@ -47,6 +47,9 @@ public class ChannelSinkConnectorConfig extends AbstractConfig {
   public static final String CHANNEL_CONFIG = "channel";
   private static final String CHANNEL_CONFIG_DOC = "The ably channel name to use for publishing.";
 
+  public static final String CHANNEL_MESSAGE_CONFIG = "channel.message.name";
+  private static final String CHANNEL_MESSAGE_CONFIG_DOC = "The ably channel message name to use for publishing.";
+
   public static final String CLIENT_KEY = "client.key";
   private static final String CLIENT_KEY_DOC = "The Ably API key string. The key string is obtained from the " +
     "application dashboard.";
@@ -323,6 +326,12 @@ public class ChannelSinkConnectorConfig extends AbstractConfig {
           .importance(Importance.HIGH)
           .build()
       )
+      .define(
+        ConfigKeyBuilder.of(CHANNEL_MESSAGE_CONFIG, Type.STRING)
+           .documentation(CHANNEL_MESSAGE_CONFIG_DOC)
+           .importance(Importance.MEDIUM)
+           .build()
+            )
       .define(
         ConfigKeyBuilder.of(CLIENT_LOG_LEVEL, Type.INT)
           .documentation(CLIENT_LOG_LEVEL_DOC)

--- a/src/main/java/com/ably/kafka/connect/ChannelSinkConnectorConfig.java
+++ b/src/main/java/com/ably/kafka/connect/ChannelSinkConnectorConfig.java
@@ -26,8 +26,6 @@ import io.ably.lib.http.HttpAuth;
 import io.ably.lib.rest.Auth.TokenParams;
 import io.ably.lib.transport.Defaults;
 import io.ably.lib.types.AblyException;
-import io.ably.lib.types.ChannelMode;
-import io.ably.lib.types.ChannelOptions;
 import io.ably.lib.types.ClientOptions;
 import io.ably.lib.types.Param;
 import io.ably.lib.types.ProxyOptions;
@@ -38,7 +36,6 @@ import com.github.jcustenborder.kafka.connect.utils.config.recommenders.Recommen
 import com.github.jcustenborder.kafka.connect.utils.config.validators.Validators;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -47,8 +44,8 @@ public class ChannelSinkConnectorConfig extends AbstractConfig {
   public static final String CHANNEL_CONFIG = "channel";
   private static final String CHANNEL_CONFIG_DOC = "The ably channel name to use for publishing.";
 
-  public static final String CHANNEL_MESSAGE_CONFIG = "channel.message.name";
-  private static final String CHANNEL_MESSAGE_CONFIG_DOC = "The ably channel message name to use for publishing.";
+  public static final String MESSAGE_CONFIG = "message.name";
+  private static final String MESSAGE_CONFIG_DOC = "Ably message name to use for publishing.";
 
   public static final String CLIENT_KEY = "client.key";
   private static final String CLIENT_KEY_DOC = "The Ably API key string. The key string is obtained from the " +
@@ -327,8 +324,8 @@ public class ChannelSinkConnectorConfig extends AbstractConfig {
           .build()
       )
       .define(
-        ConfigKeyBuilder.of(CHANNEL_MESSAGE_CONFIG, Type.STRING)
-           .documentation(CHANNEL_MESSAGE_CONFIG_DOC)
+        ConfigKeyBuilder.of(MESSAGE_CONFIG, Type.STRING)
+           .documentation(MESSAGE_CONFIG_DOC)
            .importance(Importance.MEDIUM)
            .build()
             )

--- a/src/main/java/com/ably/kafka/connect/ChannelSinkConnectorConfig.java
+++ b/src/main/java/com/ably/kafka/connect/ChannelSinkConnectorConfig.java
@@ -327,6 +327,7 @@ public class ChannelSinkConnectorConfig extends AbstractConfig {
         ConfigKeyBuilder.of(MESSAGE_CONFIG, Type.STRING)
            .documentation(MESSAGE_CONFIG_DOC)
            .importance(Importance.MEDIUM)
+           .defaultValue(null)
            .build()
             )
       .define(

--- a/src/main/java/com/ably/kafka/connect/ChannelSinkTask.java
+++ b/src/main/java/com/ably/kafka/connect/ChannelSinkTask.java
@@ -47,8 +47,9 @@ public class ChannelSinkTask extends SinkTask {
         logger.info("Starting Ably channel Sink task");
 
         final ChannelSinkConnectorConfig config = new ChannelSinkConnectorConfig(settings);
-        channelSinkMapping = new DefaultChannelSinkMapping(config, new ConfigValueEvaluator());
-        messageSinkMapping = new MessageSinkMappingImpl();
+        final ConfigValueEvaluator configValueEvaluator = new ConfigValueEvaluator();
+        channelSinkMapping = new DefaultChannelSinkMapping(config, configValueEvaluator);
+        messageSinkMapping = new MessageSinkMappingImpl(config, configValueEvaluator);
 
         if (config.clientOptions == null) {
             logger.error("Ably client options were not initialized due to invalid configuration.");

--- a/src/main/java/com/ably/kafka/connect/DefaultChannelSinkMapping.java
+++ b/src/main/java/com/ably/kafka/connect/DefaultChannelSinkMapping.java
@@ -39,7 +39,7 @@ public class DefaultChannelSinkMapping implements ChannelSinkMapping {
     private ChannelOptions getAblyChannelOptions() throws ChannelSinkConnectorConfig.ConfigException {
         final Logger logger = LoggerFactory.getLogger(ChannelSinkConnectorConfig.class);
         ChannelOptions opts;
-        String cipherKey = configValueEvaluator.evaluate(record, sinkConnectorConfig.getString(CLIENT_CHANNEL_CIPHER_KEY));
+        String cipherKey = sinkConnectorConfig.getString(CLIENT_CHANNEL_CIPHER_KEY);
 
         if (cipherKey != null && !cipherKey.trim().isEmpty()) {
             try {

--- a/src/main/java/com/ably/kafka/connect/MessageSinkMapping.java
+++ b/src/main/java/com/ably/kafka/connect/MessageSinkMapping.java
@@ -18,16 +18,14 @@ class MessageSinkMappingImpl implements MessageSinkMapping {
     private final ChannelSinkConnectorConfig sinkConnectorConfig;
     private final ConfigValueEvaluator configValueEvaluator;
 
-    public MessageSinkMappingImpl(@Nonnull ChannelSinkConnectorConfig config,@Nonnull ConfigValueEvaluator configValueEvaluator) {
+    public MessageSinkMappingImpl(@Nonnull ChannelSinkConnectorConfig config, @Nonnull ConfigValueEvaluator configValueEvaluator) {
         this.sinkConnectorConfig = config;
         this.configValueEvaluator = configValueEvaluator;
     }
 
     @Override
     public Message getMessage(SinkRecord record) {
-        final String configuredName = sinkConnectorConfig.getString(MESSAGE_CONFIG);
-        final String messageName = configuredName != null ?
-                configValueEvaluator.evaluate(record, configuredName) : null;
+        final String messageName = configValueEvaluator.evaluate(record, sinkConnectorConfig.getString(MESSAGE_CONFIG));
         Message message = new Message(messageName, record.value());
         message.id = String.format("%d:%d:%d", record.topic().hashCode(), record.kafkaPartition(), record.kafkaOffset());
 

--- a/src/main/java/com/ably/kafka/connect/MessageSinkMapping.java
+++ b/src/main/java/com/ably/kafka/connect/MessageSinkMapping.java
@@ -18,7 +18,7 @@ class MessageSinkMappingImpl implements MessageSinkMapping {
     private final ChannelSinkConnectorConfig sinkConnectorConfig;
     private final ConfigValueEvaluator configValueEvaluator;
 
-    public MessageSinkMappingImpl(@Nonnull ChannelSinkConnectorConfig config, ConfigValueEvaluator configValueEvaluator) {
+    public MessageSinkMappingImpl(@Nonnull ChannelSinkConnectorConfig config,@Nonnull ConfigValueEvaluator configValueEvaluator) {
         this.sinkConnectorConfig = config;
         this.configValueEvaluator = configValueEvaluator;
     }

--- a/src/main/java/com/ably/kafka/connect/MessageSinkMapping.java
+++ b/src/main/java/com/ably/kafka/connect/MessageSinkMapping.java
@@ -7,10 +7,7 @@ import org.apache.kafka.connect.sink.SinkRecord;
 
 import javax.annotation.Nonnull;
 
-import java.util.PrimitiveIterator;
-
-import static com.ably.kafka.connect.ChannelSinkConnectorConfig.CHANNEL_MESSAGE_CONFIG;
-import static com.ably.kafka.connect.ChannelSinkConnectorConfig.CLIENT_CHANNEL_CIPHER_KEY;
+import static com.ably.kafka.connect.ChannelSinkConnectorConfig.MESSAGE_CONFIG;
 
 public interface MessageSinkMapping {
     Message getMessage(SinkRecord record);
@@ -28,7 +25,7 @@ class MessageSinkMappingImpl implements MessageSinkMapping {
 
     @Override
     public Message getMessage(SinkRecord record) {
-        final String configuredName = sinkConnectorConfig.getString(CHANNEL_MESSAGE_CONFIG);
+        final String configuredName = sinkConnectorConfig.getString(MESSAGE_CONFIG);
         final String messageName = configuredName != null ?
                 configValueEvaluator.evaluate(record, configuredName) : null;
         Message message = new Message(messageName, record.value());

--- a/src/main/java/com/ably/kafka/connect/MessageSinkMapping.java
+++ b/src/main/java/com/ably/kafka/connect/MessageSinkMapping.java
@@ -5,16 +5,33 @@ import io.ably.lib.types.MessageExtras;
 import io.ably.lib.util.JsonUtils;
 import org.apache.kafka.connect.sink.SinkRecord;
 
+import javax.annotation.Nonnull;
+
+import java.util.PrimitiveIterator;
+
+import static com.ably.kafka.connect.ChannelSinkConnectorConfig.CHANNEL_MESSAGE_CONFIG;
+import static com.ably.kafka.connect.ChannelSinkConnectorConfig.CLIENT_CHANNEL_CIPHER_KEY;
+
 public interface MessageSinkMapping {
     Message getMessage(SinkRecord record);
 }
 
 class MessageSinkMappingImpl implements MessageSinkMapping {
+
+    private final ChannelSinkConnectorConfig sinkConnectorConfig;
+    private final ConfigValueEvaluator configValueEvaluator;
+
+    public MessageSinkMappingImpl(@Nonnull ChannelSinkConnectorConfig config, ConfigValueEvaluator configValueEvaluator) {
+        this.sinkConnectorConfig = config;
+        this.configValueEvaluator = configValueEvaluator;
+    }
+
     @Override
     public Message getMessage(SinkRecord record) {
-
-        Message message = new Message("sink", record.value());
-        //leave this as it is for now
+        final String configuredName = sinkConnectorConfig.getString(CHANNEL_MESSAGE_CONFIG);
+        final String messageName = configuredName != null ?
+                configValueEvaluator.evaluate(record, configuredName) : null;
+        Message message = new Message(messageName, record.value());
         message.id = String.format("%d:%d:%d", record.topic().hashCode(), record.kafkaPartition(), record.kafkaOffset());
 
         JsonUtils.JsonUtilsObject kafkaExtras = KafkaExtrasExtractor.createKafkaExtras(record);

--- a/src/test/java/com/ably/kafka/connect/MessageSinkMappingTest.java
+++ b/src/test/java/com/ably/kafka/connect/MessageSinkMappingTest.java
@@ -7,6 +7,7 @@ import io.ably.lib.util.JsonUtils;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.header.Header;
 import org.apache.kafka.connect.sink.SinkRecord;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
@@ -18,7 +19,15 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class MessageSinkMappingTest {
-    private MessageSinkMapping sinkMapping = new MessageSinkMappingImpl();
+    private static final String STATIC_CHANNEL_NAME = "sink-channel";
+    private static ChannelSinkConnectorConfig STATIC_CHANNEL_CONFIG = new ChannelSinkConnectorConfig(Map.of("channel", STATIC_CHANNEL_NAME, "client.key", "test-key", "client.id", "test-id"));
+
+    private MessageSinkMapping sinkMapping;
+
+    @BeforeEach
+    void setUp() {
+        sinkMapping = new MessageSinkMappingImpl(STATIC_CHANNEL_CONFIG, new ConfigValueEvaluator());
+    }
 
     /**
      * Follwoing tests only test the current state where the name is static, this is going to change when we base message

--- a/src/test/java/com/ably/kafka/connect/MessageSinkMappingTest.java
+++ b/src/test/java/com/ably/kafka/connect/MessageSinkMappingTest.java
@@ -14,22 +14,23 @@ import java.util.Base64;
 import java.util.List;
 import java.util.Map;
 
-import static com.ably.kafka.connect.ChannelSinkConnectorConfig.MESSAGE_CONFIG;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 class MessageSinkMappingTest {
     private static final String STATIC_MESSAGE_NAME = "static-message";
-    private static final Map<String,String> baseConfigMap = Map.of("channel", "channelX", "client.key", "test-key", "client.id", "test-id");
-    private static final Map<String,String> configMapWithStaticMessageName = Map.of(MESSAGE_CONFIG, STATIC_MESSAGE_NAME);
+    private static final String DYNAMIC_MESSAGE_PATTERN = "message_#{topic}_#{key}";
+    private static final Map<String,String> baseConfigMap = Map.of("channel", "channelX", "client.key",
+            "test-key", "client.id", "test-id");
+    private static final   Map<String,String> configMapWithStaticMessageName = Map.of("channel", "channelX", "client.key",
+            "test-key", "client.id", "test-id","message.name", STATIC_MESSAGE_NAME);
+    private static final   Map<String,String> configMapWithPatternedMessageName = Map.of("channel", "channelX", "client.key",
+            "test-key", "client.id", "test-id","message.name", DYNAMIC_MESSAGE_PATTERN);
     private final ConfigValueEvaluator evaluator = new ConfigValueEvaluator();
 
     private MessageSinkMapping sinkMapping;
 
-    /**
-     * Follwoing tests only test the current state where the name is static, this is going to change when we base message
-     * name on record
-     */
+
     @Test
     void testGetMessage_messageNameIsNullWhenNotProvided() {
         //given
@@ -41,6 +42,33 @@ class MessageSinkMappingTest {
 
         //then
         assertNull(message.name);
+    }
+
+    @Test
+    void testGetMessage_messageNameIsStaticWhenStaticConfigProvided() {
+        //given
+        sinkMapping = new MessageSinkMappingImpl(new ChannelSinkConnectorConfig(configMapWithStaticMessageName),evaluator);
+        final SinkRecord record = new SinkRecord("not_important", 0, Schema.BYTES_SCHEMA, "key".getBytes(), Schema.BYTES_SCHEMA, "value", 0);
+
+        //when
+        final Message message = sinkMapping.getMessage(record);
+
+        //then
+        assertEquals(STATIC_MESSAGE_NAME,message.name);
+    }
+
+    @Test
+    void testGetMessage_messageNameIsInterpolatedWhenPatternedConfigProvided() {
+        //given
+        //"message_#{topic}_#{key}"
+        sinkMapping = new MessageSinkMappingImpl(new ChannelSinkConnectorConfig(configMapWithPatternedMessageName),evaluator);
+        final SinkRecord record = new SinkRecord("niceTopic", 0, Schema.BYTES_SCHEMA, "niceKey".getBytes(), Schema.BYTES_SCHEMA, "value", 0);
+
+        //when
+        final Message message = sinkMapping.getMessage(record);
+
+        //then
+        assertEquals("message_niceTopic_niceKey",message.name);
     }
 
 
@@ -57,8 +85,9 @@ class MessageSinkMappingTest {
         assertEquals(record.value(), messageData);
     }
 
+
     @Test
-    void testGetMessage_messageId() {
+    void testGetMessage_messageIdIsSetBasedOnRecordValues() {
         //given
         sinkMapping = new MessageSinkMappingImpl(new ChannelSinkConnectorConfig(baseConfigMap),evaluator);
         final SinkRecord record = new SinkRecord("sink", 0, Schema.BYTES_SCHEMA, "key".getBytes(), Schema.BYTES_SCHEMA, "value", 0);
@@ -70,16 +99,15 @@ class MessageSinkMappingTest {
         assertEquals(messageId, String.format("%d:%d:%d", record.topic().hashCode(), record.kafkaPartition(), record.kafkaOffset()));
     }
 
+    ///Please beware that keyws we are using here are not the same as the ones used here is different than the key we use for interpolation
     @Test
-    void testGetMessage_MessageExtras_sentAndReceivedKeysAreTheSame() {
+    void testGetMessage_sentAndReceivedExtrasKeysAreTheSame() {
         //given
         sinkMapping = new MessageSinkMappingImpl(new ChannelSinkConnectorConfig(baseConfigMap),evaluator);
         final SinkRecord record = new SinkRecord("sink", 0, Schema.BYTES_SCHEMA, "key".getBytes(), Schema.BYTES_SCHEMA, "value", 0);
 
         //when
         final MessageExtras messageExtras = sinkMapping.getMessage(record).extras;
-
-        //then
         JsonUtils.JsonUtilsObject extras = JsonUtils.object();
         byte[] key = (byte[]) record.key();
         extras.add("key", Base64.getEncoder().encodeToString(key));
@@ -88,11 +116,13 @@ class MessageSinkMappingTest {
 
         String receivedKey = receivedObject.get("key").getAsString();
         String sentKey = Base64.getEncoder().encodeToString(key);
+
+        //then
         assertEquals(receivedKey, sentKey);
     }
 
     @Test
-    void testGetMessage_messageExtras_recordHeaders() {
+    void testGetMessage_recordHeadersAreReceivedCorrectly() {
         //given
         sinkMapping = new MessageSinkMappingImpl(new ChannelSinkConnectorConfig(baseConfigMap),evaluator);
         final List<Header> headersList = new ArrayList<>();


### PR DESCRIPTION
This PR adds a new optional configuration property to set message name with interpolation support.

Closes https://github.com/ably/kafka-connect-ably/issues/46