### PR TITLE
Refactor channel configuration logic

### DIFF
--- a/src/main/java/com/ably/kafka/connect/ChannelConfig.java
+++ b/src/main/java/com/ably/kafka/connect/ChannelConfig.java
@@ -1,0 +1,76 @@
+package com.ably.kafka.connect;
+
+import io.ably.lib.types.AblyException;
+import io.ably.lib.types.ChannelMode;
+import io.ably.lib.types.ChannelOptions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static com.ably.kafka.connect.ChannelSinkConnectorConfig.CHANNEL_CONFIG;
+import static com.ably.kafka.connect.ChannelSinkConnectorConfig.CLIENT_CHANNEL_CIPHER_KEY;
+import static com.ably.kafka.connect.ChannelSinkConnectorConfig.CLIENT_CHANNEL_PARAMS;
+
+interface ChannelConfig {
+    String getName();
+
+    ChannelOptions getOptions() throws ChannelSinkConnectorConfig.ConfigException;
+}
+
+class ChannelConfigImpl implements ChannelConfig {
+    private final ChannelSinkConnectorConfig sinkConnectorConfig;
+
+    public ChannelConfigImpl(ChannelSinkConnectorConfig sinkConnectorConfig) {
+        this.sinkConnectorConfig = sinkConnectorConfig;
+    }
+
+    @Override
+    public String getName() {
+        return sinkConnectorConfig.getString(CHANNEL_CONFIG);
+    }
+
+    public ChannelOptions getOptions() throws ChannelSinkConnectorConfig.ConfigException {
+        final Logger logger = LoggerFactory.getLogger(ChannelSinkConnectorConfig.class);
+        ChannelOptions opts;
+        String cipherKey = sinkConnectorConfig.getString(CLIENT_CHANNEL_CIPHER_KEY);
+
+        if (cipherKey != null && !cipherKey.trim().isEmpty()) {
+            try {
+                opts = ChannelOptions.withCipherKey(cipherKey);
+            } catch (AblyException e) {
+                logger.error("Error configuring channel cipher key", e);
+                throw new ChannelSinkConnectorConfig.ConfigException("Error configuring channel cipher key", e);
+            }
+        } else {
+            opts = new ChannelOptions();
+        }
+
+        // Since we're only publishing, set the channel mode to publish only
+        opts.modes = new ChannelMode[]{ChannelMode.publish};
+        opts.params = getParams(sinkConnectorConfig.getList(CLIENT_CHANNEL_PARAMS));
+        return opts;
+    }
+
+    private Map<String, String> getParams(List<String> params) throws ChannelSinkConnectorConfig.ConfigException {
+        final Logger logger = LoggerFactory.getLogger(ChannelSinkConnectorConfig.class);
+
+        Map<String, String> parsedParams = new HashMap<String, String>();
+        for (String param : params) {
+            String[] parts = param.split("=");
+            if (parts.length == 2) {
+                final String paramKey = parts[0];
+                final String paramVal = parts[1];
+                parsedParams.put(paramKey, paramVal);
+            } else {
+                ChannelSinkConnectorConfig.ConfigException e = new ChannelSinkConnectorConfig.ConfigException(String.format("invalid param string %s", param));
+                logger.error("invalid param in channel params configuration", e);
+                throw e;
+            }
+        }
+
+        return parsedParams;
+    }
+}

--- a/src/main/java/com/ably/kafka/connect/ChannelConfig.java
+++ b/src/main/java/com/ably/kafka/connect/ChannelConfig.java
@@ -1,18 +1,6 @@
 package com.ably.kafka.connect;
 
-import io.ably.lib.types.AblyException;
-import io.ably.lib.types.ChannelMode;
 import io.ably.lib.types.ChannelOptions;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import static com.ably.kafka.connect.ChannelSinkConnectorConfig.CHANNEL_CONFIG;
-import static com.ably.kafka.connect.ChannelSinkConnectorConfig.CLIENT_CHANNEL_CIPHER_KEY;
-import static com.ably.kafka.connect.ChannelSinkConnectorConfig.CLIENT_CHANNEL_PARAMS;
 
 interface ChannelConfig {
     String getName();
@@ -20,57 +8,3 @@ interface ChannelConfig {
     ChannelOptions getOptions() throws ChannelSinkConnectorConfig.ConfigException;
 }
 
-class ChannelConfigImpl implements ChannelConfig {
-    private final ChannelSinkConnectorConfig sinkConnectorConfig;
-
-    public ChannelConfigImpl(ChannelSinkConnectorConfig sinkConnectorConfig) {
-        this.sinkConnectorConfig = sinkConnectorConfig;
-    }
-
-    @Override
-    public String getName() {
-        return sinkConnectorConfig.getString(CHANNEL_CONFIG);
-    }
-
-    public ChannelOptions getOptions() throws ChannelSinkConnectorConfig.ConfigException {
-        final Logger logger = LoggerFactory.getLogger(ChannelSinkConnectorConfig.class);
-        ChannelOptions opts;
-        String cipherKey = sinkConnectorConfig.getString(CLIENT_CHANNEL_CIPHER_KEY);
-
-        if (cipherKey != null && !cipherKey.trim().isEmpty()) {
-            try {
-                opts = ChannelOptions.withCipherKey(cipherKey);
-            } catch (AblyException e) {
-                logger.error("Error configuring channel cipher key", e);
-                throw new ChannelSinkConnectorConfig.ConfigException("Error configuring channel cipher key", e);
-            }
-        } else {
-            opts = new ChannelOptions();
-        }
-
-        // Since we're only publishing, set the channel mode to publish only
-        opts.modes = new ChannelMode[]{ChannelMode.publish};
-        opts.params = getParams(sinkConnectorConfig.getList(CLIENT_CHANNEL_PARAMS));
-        return opts;
-    }
-
-    private Map<String, String> getParams(List<String> params) throws ChannelSinkConnectorConfig.ConfigException {
-        final Logger logger = LoggerFactory.getLogger(ChannelSinkConnectorConfig.class);
-
-        Map<String, String> parsedParams = new HashMap<String, String>();
-        for (String param : params) {
-            String[] parts = param.split("=");
-            if (parts.length == 2) {
-                final String paramKey = parts[0];
-                final String paramVal = parts[1];
-                parsedParams.put(paramKey, paramVal);
-            } else {
-                ChannelSinkConnectorConfig.ConfigException e = new ChannelSinkConnectorConfig.ConfigException(String.format("invalid param string %s", param));
-                logger.error("invalid param in channel params configuration", e);
-                throw e;
-            }
-        }
-
-        return parsedParams;
-    }
-}

--- a/src/main/java/com/ably/kafka/connect/ChannelSinkTask.java
+++ b/src/main/java/com/ably/kafka/connect/ChannelSinkTask.java
@@ -48,7 +48,7 @@ public class ChannelSinkTask extends SinkTask {
 
         final ChannelSinkConnectorConfig connectorConfig = new ChannelSinkConnectorConfig(settings);
         final ConfigValueEvaluator configValueEvaluator = new ConfigValueEvaluator();
-        final ChannelConfig channelConfig = new ChannelConfigImpl(connectorConfig);
+        final ChannelConfig channelConfig = new DefaultChannelConfig(connectorConfig);
         channelSinkMapping = new DefaultChannelSinkMapping(connectorConfig, configValueEvaluator, channelConfig);
         messageSinkMapping = new MessageSinkMappingImpl(connectorConfig, configValueEvaluator);
 

--- a/src/main/java/com/ably/kafka/connect/ChannelSinkTask.java
+++ b/src/main/java/com/ably/kafka/connect/ChannelSinkTask.java
@@ -116,6 +116,7 @@ public class ChannelSinkTask extends SinkTask {
                     throw new RetriableException("Failed to publish to Ably when queueMessages is disabled.", e);
                 }
             } catch (ChannelSinkConnectorConfig.ConfigException e) {
+                logger.error(e.getMessage(), e);
                 throw new ConnectException("Configuration error", e);
             }
         }

--- a/src/main/java/com/ably/kafka/connect/ChannelSinkTask.java
+++ b/src/main/java/com/ably/kafka/connect/ChannelSinkTask.java
@@ -46,17 +46,18 @@ public class ChannelSinkTask extends SinkTask {
     public void start(Map<String, String> settings) {
         logger.info("Starting Ably channel Sink task");
 
-        final ChannelSinkConnectorConfig config = new ChannelSinkConnectorConfig(settings);
+        final ChannelSinkConnectorConfig connectorConfig = new ChannelSinkConnectorConfig(settings);
         final ConfigValueEvaluator configValueEvaluator = new ConfigValueEvaluator();
-        channelSinkMapping = new DefaultChannelSinkMapping(config, configValueEvaluator);
-        messageSinkMapping = new MessageSinkMappingImpl(config, configValueEvaluator);
+        final ChannelConfig channelConfig = new ChannelConfigImpl(connectorConfig);
+        channelSinkMapping = new DefaultChannelSinkMapping(connectorConfig, configValueEvaluator, channelConfig);
+        messageSinkMapping = new MessageSinkMappingImpl(connectorConfig, configValueEvaluator);
 
-        if (config.clientOptions == null) {
+        if (connectorConfig.clientOptions == null) {
             logger.error("Ably client options were not initialized due to invalid configuration.");
             return;
         }
 
-        config.clientOptions.logHandler = (severity, tag, msg, tr) -> {
+        connectorConfig.clientOptions.logHandler = (severity, tag, msg, tr) -> {
             if (severity < 0 || severity >= severities.length) {
                 severity = 3;
             }
@@ -89,7 +90,7 @@ public class ChannelSinkTask extends SinkTask {
         };
 
         try {
-            ably = new AblyRealtime(config.clientOptions);
+            ably = new AblyRealtime(connectorConfig.clientOptions);
         } catch (AblyException e) {
             logger.error("error initializing ably client", e);
         }

--- a/src/main/java/com/ably/kafka/connect/DefaultChannelConfig.java
+++ b/src/main/java/com/ably/kafka/connect/DefaultChannelConfig.java
@@ -3,8 +3,6 @@ package com.ably.kafka.connect;
 import io.ably.lib.types.AblyException;
 import io.ably.lib.types.ChannelMode;
 import io.ably.lib.types.ChannelOptions;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.HashMap;
 import java.util.List;
@@ -27,7 +25,6 @@ class DefaultChannelConfig implements ChannelConfig {
     }
 
     public ChannelOptions getOptions() throws ChannelSinkConnectorConfig.ConfigException {
-        final Logger logger = LoggerFactory.getLogger(ChannelSinkConnectorConfig.class);
         ChannelOptions channelOptions;
         final String cipherKey = sinkConnectorConfig.getString(CLIENT_CHANNEL_CIPHER_KEY);
 
@@ -35,7 +32,6 @@ class DefaultChannelConfig implements ChannelConfig {
             try {
                 channelOptions = ChannelOptions.withCipherKey(cipherKey);
             } catch (AblyException e) {
-                logger.error("Error configuring channel cipher key", e);
                 throw new ChannelSinkConnectorConfig.ConfigException("Error configuring channel cipher key", e);
             }
         } else {
@@ -49,8 +45,6 @@ class DefaultChannelConfig implements ChannelConfig {
     }
 
     private Map<String, String> getParams(final List<String> params) throws ChannelSinkConnectorConfig.ConfigException {
-        final Logger logger = LoggerFactory.getLogger(ChannelSinkConnectorConfig.class);
-
         final Map<String, String> parsedParams = new HashMap<>();
         for (final String param : params) {
             final String[] parts = param.split("=");
@@ -59,9 +53,7 @@ class DefaultChannelConfig implements ChannelConfig {
                 final String paramVal = parts[1];
                 parsedParams.put(paramKey, paramVal);
             } else {
-                ChannelSinkConnectorConfig.ConfigException e = new ChannelSinkConnectorConfig.ConfigException(String.format("invalid param string %s", param));
-                logger.error("invalid param in channel params configuration", e);
-                throw e;
+                throw new ChannelSinkConnectorConfig.ConfigException(String.format("invalid param in channel params configuration %s", param));
             }
         }
 

--- a/src/main/java/com/ably/kafka/connect/DefaultChannelConfig.java
+++ b/src/main/java/com/ably/kafka/connect/DefaultChannelConfig.java
@@ -31,7 +31,7 @@ class DefaultChannelConfig implements ChannelConfig {
         ChannelOptions channelOptions;
         final String cipherKey = sinkConnectorConfig.getString(CLIENT_CHANNEL_CIPHER_KEY);
 
-        if (cipherKey != null && !cipherKey.trim().isEmpty()) {
+        if (cipherKey != null) {
             try {
                 channelOptions = ChannelOptions.withCipherKey(cipherKey);
             } catch (AblyException e) {

--- a/src/main/java/com/ably/kafka/connect/DefaultChannelConfig.java
+++ b/src/main/java/com/ably/kafka/connect/DefaultChannelConfig.java
@@ -1,0 +1,70 @@
+package com.ably.kafka.connect;
+
+import io.ably.lib.types.AblyException;
+import io.ably.lib.types.ChannelMode;
+import io.ably.lib.types.ChannelOptions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static com.ably.kafka.connect.ChannelSinkConnectorConfig.CHANNEL_CONFIG;
+import static com.ably.kafka.connect.ChannelSinkConnectorConfig.CLIENT_CHANNEL_CIPHER_KEY;
+import static com.ably.kafka.connect.ChannelSinkConnectorConfig.CLIENT_CHANNEL_PARAMS;
+
+class DefaultChannelConfig implements ChannelConfig {
+    private final ChannelSinkConnectorConfig sinkConnectorConfig;
+
+    public DefaultChannelConfig(ChannelSinkConnectorConfig sinkConnectorConfig) {
+        this.sinkConnectorConfig = sinkConnectorConfig;
+    }
+
+    @Override
+    public String getName() {
+        return sinkConnectorConfig.getString(CHANNEL_CONFIG);
+    }
+
+    public ChannelOptions getOptions() throws ChannelSinkConnectorConfig.ConfigException {
+        final Logger logger = LoggerFactory.getLogger(ChannelSinkConnectorConfig.class);
+        ChannelOptions opts;
+        String cipherKey = sinkConnectorConfig.getString(CLIENT_CHANNEL_CIPHER_KEY);
+
+        if (cipherKey != null && !cipherKey.trim().isEmpty()) {
+            try {
+                opts = ChannelOptions.withCipherKey(cipherKey);
+            } catch (AblyException e) {
+                logger.error("Error configuring channel cipher key", e);
+                throw new ChannelSinkConnectorConfig.ConfigException("Error configuring channel cipher key", e);
+            }
+        } else {
+            opts = new ChannelOptions();
+        }
+
+        // Since we're only publishing, set the channel mode to publish only
+        opts.modes = new ChannelMode[]{ChannelMode.publish};
+        opts.params = getParams(sinkConnectorConfig.getList(CLIENT_CHANNEL_PARAMS));
+        return opts;
+    }
+
+    private Map<String, String> getParams(List<String> params) throws ChannelSinkConnectorConfig.ConfigException {
+        final Logger logger = LoggerFactory.getLogger(ChannelSinkConnectorConfig.class);
+
+        Map<String, String> parsedParams = new HashMap<String, String>();
+        for (String param : params) {
+            String[] parts = param.split("=");
+            if (parts.length == 2) {
+                final String paramKey = parts[0];
+                final String paramVal = parts[1];
+                parsedParams.put(paramKey, paramVal);
+            } else {
+                ChannelSinkConnectorConfig.ConfigException e = new ChannelSinkConnectorConfig.ConfigException(String.format("invalid param string %s", param));
+                logger.error("invalid param in channel params configuration", e);
+                throw e;
+            }
+        }
+
+        return parsedParams;
+    }
+}

--- a/src/main/java/com/ably/kafka/connect/DefaultChannelConfig.java
+++ b/src/main/java/com/ably/kafka/connect/DefaultChannelConfig.java
@@ -17,7 +17,7 @@ import static com.ably.kafka.connect.ChannelSinkConnectorConfig.CLIENT_CHANNEL_P
 class DefaultChannelConfig implements ChannelConfig {
     private final ChannelSinkConnectorConfig sinkConnectorConfig;
 
-    public DefaultChannelConfig(ChannelSinkConnectorConfig sinkConnectorConfig) {
+    public DefaultChannelConfig(final ChannelSinkConnectorConfig sinkConnectorConfig) {
         this.sinkConnectorConfig = sinkConnectorConfig;
     }
 
@@ -28,32 +28,32 @@ class DefaultChannelConfig implements ChannelConfig {
 
     public ChannelOptions getOptions() throws ChannelSinkConnectorConfig.ConfigException {
         final Logger logger = LoggerFactory.getLogger(ChannelSinkConnectorConfig.class);
-        ChannelOptions opts;
-        String cipherKey = sinkConnectorConfig.getString(CLIENT_CHANNEL_CIPHER_KEY);
+        ChannelOptions channelOptions;
+        final String cipherKey = sinkConnectorConfig.getString(CLIENT_CHANNEL_CIPHER_KEY);
 
         if (cipherKey != null && !cipherKey.trim().isEmpty()) {
             try {
-                opts = ChannelOptions.withCipherKey(cipherKey);
+                channelOptions = ChannelOptions.withCipherKey(cipherKey);
             } catch (AblyException e) {
                 logger.error("Error configuring channel cipher key", e);
                 throw new ChannelSinkConnectorConfig.ConfigException("Error configuring channel cipher key", e);
             }
         } else {
-            opts = new ChannelOptions();
+            channelOptions = new ChannelOptions();
         }
 
         // Since we're only publishing, set the channel mode to publish only
-        opts.modes = new ChannelMode[]{ChannelMode.publish};
-        opts.params = getParams(sinkConnectorConfig.getList(CLIENT_CHANNEL_PARAMS));
-        return opts;
+        channelOptions.modes = new ChannelMode[]{ChannelMode.publish};
+        channelOptions.params = getParams(sinkConnectorConfig.getList(CLIENT_CHANNEL_PARAMS));
+        return channelOptions;
     }
 
-    private Map<String, String> getParams(List<String> params) throws ChannelSinkConnectorConfig.ConfigException {
+    private Map<String, String> getParams(final List<String> params) throws ChannelSinkConnectorConfig.ConfigException {
         final Logger logger = LoggerFactory.getLogger(ChannelSinkConnectorConfig.class);
 
-        Map<String, String> parsedParams = new HashMap<String, String>();
-        for (String param : params) {
-            String[] parts = param.split("=");
+        final Map<String, String> parsedParams = new HashMap<>();
+        for (final String param : params) {
+            final String[] parts = param.split("=");
             if (parts.length == 2) {
                 final String paramKey = parts[0];
                 final String paramVal = parts[1];

--- a/src/main/java/com/ably/kafka/connect/DefaultChannelSinkMapping.java
+++ b/src/main/java/com/ably/kafka/connect/DefaultChannelSinkMapping.java
@@ -3,78 +3,23 @@ package com.ably.kafka.connect;
 import io.ably.lib.realtime.AblyRealtime;
 import io.ably.lib.realtime.Channel;
 import io.ably.lib.types.AblyException;
-import io.ably.lib.types.ChannelMode;
-import io.ably.lib.types.ChannelOptions;
 import org.apache.kafka.connect.sink.SinkRecord;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import static com.ably.kafka.connect.ChannelSinkConnectorConfig.*;
-
 public class DefaultChannelSinkMapping implements ChannelSinkMapping {
-    private final ChannelSinkConnectorConfig sinkConnectorConfig;
     private final ConfigValueEvaluator configValueEvaluator;
+    private final ChannelConfig channelConfig;
 
-    public DefaultChannelSinkMapping(@Nonnull ChannelSinkConnectorConfig config, ConfigValueEvaluator configValueEvaluator) {
-        sinkConnectorConfig = config;
+    public DefaultChannelSinkMapping(@Nonnull ChannelSinkConnectorConfig config, ConfigValueEvaluator configValueEvaluator, ChannelConfig channelConfig) {
         this.configValueEvaluator = configValueEvaluator;
+        this.channelConfig = channelConfig;
     }
 
     @Override
     public Channel getChannel(@Nonnull SinkRecord sinkRecord, @Nonnull AblyRealtime ablyRealtime) throws AblyException,
             ChannelSinkConnectorConfig.ConfigException {
-        return ablyRealtime.channels.get(getAblyChannelName(sinkRecord), getAblyChannelOptions());
-    }
-
-    private String getAblyChannelName(SinkRecord sinkRecord) {
-        return configValueEvaluator.evaluate(sinkRecord, sinkConnectorConfig.getString(CHANNEL_CONFIG));
-    }
-
-    private ChannelOptions getAblyChannelOptions() throws ChannelSinkConnectorConfig.ConfigException {
-        final Logger logger = LoggerFactory.getLogger(ChannelSinkConnectorConfig.class);
-        ChannelOptions opts;
-        String cipherKey = sinkConnectorConfig.getString(CLIENT_CHANNEL_CIPHER_KEY);
-
-        if (cipherKey != null && !cipherKey.trim().isEmpty()) {
-            try {
-                opts = ChannelOptions.withCipherKey(cipherKey);
-            } catch (AblyException e) {
-                logger.error("Error configuring channel cipher key", e);
-                throw new ChannelSinkConnectorConfig.ConfigException("Error configuring channel cipher key", e);
-            }
-        } else {
-            opts = new ChannelOptions();
-        }
-
-        // Since we're only publishing, set the channel mode to publish only
-        opts.modes = new ChannelMode[]{ChannelMode.publish};
-        opts.params = getChannelParams(sinkConnectorConfig.getList(CLIENT_CHANNEL_PARAMS));
-        return opts;
-    }
-
-    private Map<String, String> getChannelParams(List<String> params) throws ChannelSinkConnectorConfig.ConfigException {
-        final Logger logger = LoggerFactory.getLogger(ChannelSinkConnectorConfig.class);
-
-        Map<String, String> parsedParams = new HashMap<String, String>();
-        for (String param : params) {
-            String[] parts = param.split("=");
-            if (parts.length == 2) {
-                final String paramKey = parts[0];
-                final String paramVal = parts[1];
-                parsedParams.put(paramKey, paramVal);
-            } else {
-                ChannelSinkConnectorConfig.ConfigException e = new ChannelSinkConnectorConfig.ConfigException(String.format("invalid param string %s", param));
-                logger.error("invalid param in channel params configuration", e);
-                throw e;
-            }
-        }
-
-        return parsedParams;
+        final String channelName = configValueEvaluator.evaluate(sinkRecord, channelConfig.getName());
+        return ablyRealtime.channels.get(channelName, channelConfig.getOptions());
     }
 }

--- a/src/test/java/com/ably/kafka/connect/DefaultChannelSinkMappingTest.java
+++ b/src/test/java/com/ably/kafka/connect/DefaultChannelSinkMappingTest.java
@@ -33,7 +33,7 @@ class DefaultChannelSinkMappingTest {
     @Test
     void testGetChannel_static_name_is_exactly_the_same() throws AblyException, ChannelSinkConnectorConfig.ConfigException {
         //given
-        defaultChannelSinkMapping = new DefaultChannelSinkMapping(STATIC_CHANNEL_CONFIG, new ConfigValueEvaluator());
+        defaultChannelSinkMapping = new DefaultChannelSinkMapping(STATIC_CHANNEL_CONFIG, new ConfigValueEvaluator(), new ChannelConfigImpl(STATIC_CHANNEL_CONFIG));
         SinkRecord record = new SinkRecord("topic", 0, null, null, null, null, 0);
 
         //when
@@ -48,7 +48,7 @@ class DefaultChannelSinkMappingTest {
         //given
         SinkRecord record = new SinkRecord("myTopic", 0, null, "myKey".getBytes(), null, null, 0);
         final ChannelSinkConnectorConfig connectorConfig = new ChannelSinkConnectorConfig(Map.of("channel", "channel_#{key}_#{topic}", "client.key", "test-key", "client.id", "test-id"));
-        defaultChannelSinkMapping = new DefaultChannelSinkMapping(connectorConfig, new ConfigValueEvaluator());
+        defaultChannelSinkMapping = new DefaultChannelSinkMapping(connectorConfig, new ConfigValueEvaluator(), new ChannelConfigImpl(connectorConfig));
 
         //when
         final Channel channel = defaultChannelSinkMapping.getChannel(record, ablyRealtime);

--- a/src/test/java/com/ably/kafka/connect/DefaultChannelSinkMappingTest.java
+++ b/src/test/java/com/ably/kafka/connect/DefaultChannelSinkMappingTest.java
@@ -33,7 +33,7 @@ class DefaultChannelSinkMappingTest {
     @Test
     void testGetChannel_static_name_is_exactly_the_same() throws AblyException, ChannelSinkConnectorConfig.ConfigException {
         //given
-        defaultChannelSinkMapping = new DefaultChannelSinkMapping(STATIC_CHANNEL_CONFIG, new ConfigValueEvaluator(), new ChannelConfigImpl(STATIC_CHANNEL_CONFIG));
+        defaultChannelSinkMapping = new DefaultChannelSinkMapping(STATIC_CHANNEL_CONFIG, new ConfigValueEvaluator(), new DefaultChannelConfig(STATIC_CHANNEL_CONFIG));
         SinkRecord record = new SinkRecord("topic", 0, null, null, null, null, 0);
 
         //when
@@ -48,7 +48,7 @@ class DefaultChannelSinkMappingTest {
         //given
         SinkRecord record = new SinkRecord("myTopic", 0, null, "myKey".getBytes(), null, null, 0);
         final ChannelSinkConnectorConfig connectorConfig = new ChannelSinkConnectorConfig(Map.of("channel", "channel_#{key}_#{topic}", "client.key", "test-key", "client.id", "test-id"));
-        defaultChannelSinkMapping = new DefaultChannelSinkMapping(connectorConfig, new ConfigValueEvaluator(), new ChannelConfigImpl(connectorConfig));
+        defaultChannelSinkMapping = new DefaultChannelSinkMapping(connectorConfig, new ConfigValueEvaluator(), new DefaultChannelConfig(connectorConfig));
 
         //when
         final Channel channel = defaultChannelSinkMapping.getChannel(record, ablyRealtime);


### PR DESCRIPTION
This PR addresses https://github.com/ably/kafka-connect-ably/issues/44 raised by @QuintinWillison and creates a separate channel configuration class to retrieve channel related configuration values. 

Closes https://github.com/ably/kafka-connect-ably/issues/44