### PR TITLE
Remove recover config

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,6 @@ The advanced properties that can be configured for the connector are:
 | client.push.full.wait | Sets whether Ably should wait for all the effects of push REST requests before responding. | *Boolean* ||
 | client.queue.messages | Sets whether the default queueing of messages when connection states that anticipate an imminent connection (connecting and disconnected) are suppressed or not. If set to `false`, publish and presence state changes will fail immediately if not in the connected state. | *Boolean* | True |
 | client.realtime.request.timeout | The timeout period before a realtime client library establishing a connection with Ably, or sending a `HEARTBEAT`, `CONNECT`, `ATTACH`, `DETACH` or `CLOSE` `ProtocolMessage` to Ably, will consider that request as failed and trigger a suitable failure condition. | *Long* | 10000 |
-| client.recover | A connection recovery string, specified by a client when initializing the library with the intention of inheriting the state of an earlier connection. | *String* ||
 | client.tls | Sets whether TLS is used for all connection types. | *Boolean* | True |
 | client.token.params | Sets whether the configured token parameters are used. | *Boolean* ||
 | client.token.params.capability | Stringified JSON capability requirements for the token. When omitted, the REST API default to allow all operations is applied by Ably, with the string value `{“*”:[“*”]}`. Requires `client.token.params` to be set to `true`. | *String* ||

--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ The advanced properties that can be configured for the connector are:
 | client.push.full.wait | Sets whether Ably should wait for all the effects of push REST requests before responding. | *Boolean* ||
 | client.queue.messages | Sets whether the default queueing of messages when connection states that anticipate an imminent connection (connecting and disconnected) are suppressed or not. If set to `false`, publish and presence state changes will fail immediately if not in the connected state. | *Boolean* | True |
 | client.realtime.request.timeout | The timeout period before a realtime client library establishing a connection with Ably, or sending a `HEARTBEAT`, `CONNECT`, `ATTACH`, `DETACH` or `CLOSE` `ProtocolMessage` to Ably, will consider that request as failed and trigger a suitable failure condition. | *Long* | 10000 |
+| client.recover | A connection recovery string, specified by a client when initializing the library with the intention of inheriting the state of an earlier connection. | *String* ||
 | client.tls | Sets whether TLS is used for all connection types. | *Boolean* | True |
 | client.token.params | Sets whether the configured token parameters are used. | *Boolean* ||
 | client.token.params.capability | Stringified JSON capability requirements for the token. When omitted, the REST API default to allow all operations is applied by Ably, with the string value `{“*”:[“*”]}`. Requires `client.token.params` to be set to `true`. | *String* ||

--- a/src/main/java/com/ably/kafka/connect/ChannelSinkConnectorConfig.java
+++ b/src/main/java/com/ably/kafka/connect/ChannelSinkConnectorConfig.java
@@ -85,11 +85,6 @@ public class ChannelSinkConnectorConfig extends AbstractConfig {
     private static final String CLIENT_ECHO_MESSAGES_DOC = "If false, suppresses messages originating from this " +
         "connection being echoed back on the same connection.";
 
-    public static final String CLIENT_RECOVER = "client.recover";
-    private static final String CLIENT_RECOVER_DOC = "A connection recovery string, specified by a client when " +
-        "initialising the library with the intention of inheriting the state of an earlier connection. See the Ably " +
-        "Realtime API documentation for further information on connection state recovery.";
-
     public static final String CLIENT_PROXY = "client.proxy";
     private static final String CLIENT_PROXY_DOC = "If true, use the configured proxy options to proxy connections.";
 
@@ -236,7 +231,6 @@ public class ChannelSinkConnectorConfig extends AbstractConfig {
         opts.useBinaryProtocol = getBoolean(CLIENT_USE_BINARY_PROTOCOL);
         opts.queueMessages = getBoolean(CLIENT_QUEUE_MESSAGES);
         opts.echoMessages = getBoolean(CLIENT_ECHO_MESSAGES);
-        opts.recover = getString(CLIENT_RECOVER);
         if (getBoolean(CLIENT_PROXY)) {
             ProxyOptions proxyOpts = new ProxyOptions();
             proxyOpts.host = getString(CLIENT_PROXY_HOST);
@@ -395,13 +389,6 @@ public class ChannelSinkConnectorConfig extends AbstractConfig {
                     .documentation(CLIENT_ECHO_MESSAGES_DOC)
                     .importance(Importance.MEDIUM)
                     .defaultValue(true)
-                    .build()
-            )
-            .define(
-                ConfigKeyBuilder.of(CLIENT_RECOVER, Type.STRING)
-                    .documentation(CLIENT_RECOVER_DOC)
-                    .importance(Importance.MEDIUM)
-                    .defaultValue("")
                     .build()
             )
             .define(

--- a/src/main/java/com/ably/kafka/connect/ChannelSinkConnectorConfig.java
+++ b/src/main/java/com/ably/kafka/connect/ChannelSinkConnectorConfig.java
@@ -85,6 +85,11 @@ public class ChannelSinkConnectorConfig extends AbstractConfig {
     private static final String CLIENT_ECHO_MESSAGES_DOC = "If false, suppresses messages originating from this " +
         "connection being echoed back on the same connection.";
 
+    public static final String CLIENT_RECOVER = "client.recover";
+    private static final String CLIENT_RECOVER_DOC = "A connection recovery string, specified by a client when " +
+        "initialising the library with the intention of inheriting the state of an earlier connection. See the Ably " +
+        "Realtime API documentation for further information on connection state recovery.";
+
     public static final String CLIENT_PROXY = "client.proxy";
     private static final String CLIENT_PROXY_DOC = "If true, use the configured proxy options to proxy connections.";
 
@@ -231,6 +236,7 @@ public class ChannelSinkConnectorConfig extends AbstractConfig {
         opts.useBinaryProtocol = getBoolean(CLIENT_USE_BINARY_PROTOCOL);
         opts.queueMessages = getBoolean(CLIENT_QUEUE_MESSAGES);
         opts.echoMessages = getBoolean(CLIENT_ECHO_MESSAGES);
+        opts.recover = getString(CLIENT_RECOVER);
         if (getBoolean(CLIENT_PROXY)) {
             ProxyOptions proxyOpts = new ProxyOptions();
             proxyOpts.host = getString(CLIENT_PROXY_HOST);
@@ -389,6 +395,13 @@ public class ChannelSinkConnectorConfig extends AbstractConfig {
                     .documentation(CLIENT_ECHO_MESSAGES_DOC)
                     .importance(Importance.MEDIUM)
                     .defaultValue(true)
+                    .build()
+            )
+            .define(
+                ConfigKeyBuilder.of(CLIENT_RECOVER, Type.STRING)
+                    .documentation(CLIENT_RECOVER_DOC)
+                    .importance(Importance.MEDIUM)
+                    .defaultValue("")
                     .build()
             )
             .define(


### PR DESCRIPTION
This PR removes `client.recover` property from configuration. As suggested by @lmars 