### PR TITLE
Remove client.use.binary.protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,6 @@ The advanced properties that can be configured for the connector are:
 | client.token.params.client.id | The client ID to include with the token. Requires `client.token.params` to be set to `true`. | *String* ||
 | client.token.params.ttl | The requested time to live (TTL) for the token in milliseconds. When omitted, the REST API default of 60 minutes is applied by Ably. Requires `client.token.params` to be set to `true`. | *Boolean* | 0 |
 | client.transport.params | Any additional parameters to be sent in the query string when initiating a realtime connection in the format `key1=value1,key2=value` without URL encoding. | *List* ||
-| client.use.binary.protocol | Set to `false` to force the library to use JSON encoding for REST and realtime operations, instead of msgpack encoding. | *Boolean* | True |
 | client.loglevel | Sets the verbosity of logging. | *Integer* | 0 |
 
 ## Dynamic Channel Configuration

--- a/src/main/java/com/ably/kafka/connect/ChannelSinkConnectorConfig.java
+++ b/src/main/java/com/ably/kafka/connect/ChannelSinkConnectorConfig.java
@@ -72,10 +72,6 @@ public class ChannelSinkConnectorConfig extends AbstractConfig {
     private static final String CLIENT_AUTO_CONNECT_DOC = "If false, suppresses the automatic initiation of a " +
         "connection when the library is instanced.";
 
-    public static final String CLIENT_USE_BINARY_PROTOCOL = "client.use.binary.protocol";
-    private static final String CLIENT_USE_BINARY_PROTOCOL_DOC = "If false, forces the library to use the JSON " +
-        "encoding for REST and Realtime operations, instead of the default binary msgpack encoding.";
-
     public static final String CLIENT_QUEUE_MESSAGES = "client.queue.messages";
     private static final String CLIENT_QUEUE_MESSAGES_DOC = "If false, suppresses the default queueing of messages " +
         "when connection states that anticipate imminent connection (connecting and disconnected). Instead, publish " +
@@ -228,7 +224,6 @@ public class ChannelSinkConnectorConfig extends AbstractConfig {
         opts.port = getInt(CLIENT_PORT);
         opts.tlsPort = getInt(CLIENT_TLS_PORT);
         opts.autoConnect = getBoolean(CLIENT_AUTO_CONNECT);
-        opts.useBinaryProtocol = getBoolean(CLIENT_USE_BINARY_PROTOCOL);
         opts.queueMessages = getBoolean(CLIENT_QUEUE_MESSAGES);
         opts.echoMessages = getBoolean(CLIENT_ECHO_MESSAGES);
         if (getBoolean(CLIENT_PROXY)) {
@@ -366,13 +361,6 @@ public class ChannelSinkConnectorConfig extends AbstractConfig {
             .define(
                 ConfigKeyBuilder.of(CLIENT_AUTO_CONNECT, Type.BOOLEAN)
                     .documentation(CLIENT_AUTO_CONNECT_DOC)
-                    .importance(Importance.MEDIUM)
-                    .defaultValue(true)
-                    .build()
-            )
-            .define(
-                ConfigKeyBuilder.of(CLIENT_USE_BINARY_PROTOCOL, Type.BOOLEAN)
-                    .documentation(CLIENT_USE_BINARY_PROTOCOL_DOC)
                     .importance(Importance.MEDIUM)
                     .defaultValue(true)
                     .build()


### PR DESCRIPTION
This PR removes `client.use.binary.protocol` from connector and Readme.

Discussed with @SimonWoolf and captured with https://github.com/ably/ably-java/issues/758

Two reasons
* The way ably-java handle this option
* This was a property developed for clients who can't handle binary which is not the case for our conector

Closes https://github.com/ably/kafka-connect-ably/issues/57