### PR TITLE
Update Kafka advertised listeners and expose ports

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,16 +16,19 @@ services:
       kafka_network:
         aliases:
           - kafka
-    # ports:
-    #  - '9092:9092'
+    ports:
+      - 29092:29092
     depends_on:
       - zookeeper
     environment:
       KAFKA_ZOOKEEPER_CONNECT: 'zookeeper:2181'
-      KAFKA_ADVERTISED_LISTENERS: 'PLAINTEXT://:9092'
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
       KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
       KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+      KAFKA_LISTENERS: PLAINTEXT://:9092, EXTERNAL_LISTENER://:29092
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092, EXTERNAL_LISTENER://localhost:29092
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT, EXTERNAL_LISTENER:PLAINTEXT
+      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
 
   schema-registry:
     image: confluentinc/cp-schema-registry:5.4.0

--- a/src/main/java/com/ably/kafka/connect/client/DefaultAblyClientFactory.java
+++ b/src/main/java/com/ably/kafka/connect/client/DefaultAblyClientFactory.java
@@ -23,7 +23,7 @@ public class DefaultAblyClientFactory implements AblyClientFactory {
         final ChannelSinkConnectorConfig connectorConfig = new ChannelSinkConnectorConfig(settings);
         final ConfigValueEvaluator configValueEvaluator = new ConfigValueEvaluator();
         final ChannelConfig channelConfig = new DefaultChannelConfig(connectorConfig);
-        final ChannelSinkMapping channelSinkMapping = new DefaultChannelSinkMapping(connectorConfig, configValueEvaluator, channelConfig);
+        final ChannelSinkMapping channelSinkMapping = new DefaultChannelSinkMapping(configValueEvaluator, channelConfig);
         final MessageSinkMapping messageSinkMapping = new DefaultMessageSinkMapping(connectorConfig, configValueEvaluator);
         if (connectorConfig.clientOptions == null) {
             throw new ConfigException("Ably client options were not initialized due to invalid configuration.");

--- a/src/main/java/com/ably/kafka/connect/mapping/DefaultChannelSinkMapping.java
+++ b/src/main/java/com/ably/kafka/connect/mapping/DefaultChannelSinkMapping.java
@@ -14,7 +14,7 @@ public class DefaultChannelSinkMapping implements ChannelSinkMapping {
     private final ConfigValueEvaluator configValueEvaluator;
     private final ChannelConfig channelConfig;
 
-    public DefaultChannelSinkMapping(@Nonnull ChannelSinkConnectorConfig config, ConfigValueEvaluator configValueEvaluator, ChannelConfig channelConfig) {
+    public DefaultChannelSinkMapping(ConfigValueEvaluator configValueEvaluator, ChannelConfig channelConfig) {
         this.configValueEvaluator = configValueEvaluator;
         this.channelConfig = channelConfig;
     }

--- a/src/test/java/com/ably/kafka/connect/DefaultChannelSinkMappingTest.java
+++ b/src/test/java/com/ably/kafka/connect/DefaultChannelSinkMappingTest.java
@@ -37,7 +37,7 @@ class DefaultChannelSinkMappingTest {
     @Test
     void testGetChannel_static_name_is_exactly_the_same() throws AblyException, ChannelSinkConnectorConfig.ConfigException {
         //given
-        defaultChannelSinkMapping = new DefaultChannelSinkMapping(STATIC_CHANNEL_CONFIG, new ConfigValueEvaluator(), new DefaultChannelConfig(STATIC_CHANNEL_CONFIG));
+        defaultChannelSinkMapping = new DefaultChannelSinkMapping(new ConfigValueEvaluator(), new DefaultChannelConfig(STATIC_CHANNEL_CONFIG));
         SinkRecord record = new SinkRecord("topic", 0, null, null, null, null, 0);
 
         //when
@@ -52,7 +52,7 @@ class DefaultChannelSinkMappingTest {
         //given
         SinkRecord record = new SinkRecord("myTopic", 0, null, "myKey".getBytes(), null, null, 0);
         final ChannelSinkConnectorConfig connectorConfig = new ChannelSinkConnectorConfig(Map.of("channel", "channel_#{key}_#{topic}", "client.key", "test-key", "client.id", "test-id"));
-        defaultChannelSinkMapping = new DefaultChannelSinkMapping(connectorConfig, new ConfigValueEvaluator(), new DefaultChannelConfig(connectorConfig));
+        defaultChannelSinkMapping = new DefaultChannelSinkMapping(new ConfigValueEvaluator(), new DefaultChannelConfig(connectorConfig));
 
         //when
         final Channel channel = defaultChannelSinkMapping.getChannel(record, ablyRealtime);


### PR DESCRIPTION
This PR exposes Kafka connect advertised listener ports so that listeners outside of Docker could produce / consume messages