### PR TITLE
A proof of concept individual channel encryption

### DIFF
--- a/src/main/java/com/ably/kafka/connect/config/ChannelConfig.java
+++ b/src/main/java/com/ably/kafka/connect/config/ChannelConfig.java
@@ -1,10 +1,11 @@
 package com.ably.kafka.connect.config;
 
 import io.ably.lib.types.ChannelOptions;
+import org.apache.kafka.connect.sink.SinkRecord;
 
 public interface ChannelConfig {
     String getName();
 
-    ChannelOptions getOptions() throws ChannelSinkConnectorConfig.ConfigException;
+    ChannelOptions getOptions(SinkRecord record) throws ChannelSinkConnectorConfig.ConfigException;
 }
 

--- a/src/main/java/com/ably/kafka/connect/config/ChannelSinkConnectorConfig.java
+++ b/src/main/java/com/ably/kafka/connect/config/ChannelSinkConnectorConfig.java
@@ -173,6 +173,9 @@ public class ChannelSinkConnectorConfig extends AbstractConfig {
     private static final String CLIENT_CHANNEL_CIPHER_KEY_DOC = "Requests encryption for this channel when not null, " +
         "and specifies encryption-related parameters (such as algorithm, chaining mode, key length and key).";
 
+    public static final String CIPHER_KEY_CLASS = "client.channel.cipher.key.class";
+    private static final String CIPHER_KEY_CLASS_DOC = "Class that generates cipher key";
+
     public static final String CLIENT_CHANNEL_PARAMS = "client.channel.params";
     private static final String CLIENT_CHANNEL_PARAMS_DOC = "Additional channel parameters used to configure the " +
         "behaviour of the channel. This should be specified in the form \"key1=value1,key2=value2,...\".";
@@ -538,6 +541,13 @@ public class ChannelSinkConnectorConfig extends AbstractConfig {
             .define(
                 ConfigKeyBuilder.of(CLIENT_CHANNEL_CIPHER_KEY, Type.STRING)
                     .documentation(CLIENT_CHANNEL_CIPHER_KEY_DOC)
+                    .importance(Importance.MEDIUM)
+                    .defaultValue(null)
+                    .build()
+            )
+            .define(
+                ConfigKeyBuilder.of(CIPHER_KEY_CLASS, Type.CLASS)
+                    .documentation(CIPHER_KEY_CLASS_DOC)
                     .importance(Importance.MEDIUM)
                     .defaultValue(null)
                     .build()

--- a/src/main/java/com/ably/kafka/connect/config/ChannelSinkConnectorConfig.java
+++ b/src/main/java/com/ably/kafka/connect/config/ChannelSinkConnectorConfig.java
@@ -173,8 +173,8 @@ public class ChannelSinkConnectorConfig extends AbstractConfig {
     private static final String CLIENT_CHANNEL_CIPHER_KEY_DOC = "Requests encryption for this channel when not null, " +
         "and specifies encryption-related parameters (such as algorithm, chaining mode, key length and key).";
 
-    public static final String CIPHER_KEY_CLASS = "client.channel.cipher.key.class";
-    private static final String CIPHER_KEY_CLASS_DOC = "Class that generates cipher key";
+    public static final String CIPHER_KEY_GENERATOR_CLASS = "client.channel.cipher.key.class";
+    private static final String CIPHER_KEY_GENERATOR_CLASS_DOC = "Class that generates cipher key";
 
     public static final String CLIENT_CHANNEL_PARAMS = "client.channel.params";
     private static final String CLIENT_CHANNEL_PARAMS_DOC = "Additional channel parameters used to configure the " +
@@ -546,8 +546,8 @@ public class ChannelSinkConnectorConfig extends AbstractConfig {
                     .build()
             )
             .define(
-                ConfigKeyBuilder.of(CIPHER_KEY_CLASS, Type.CLASS)
-                    .documentation(CIPHER_KEY_CLASS_DOC)
+                ConfigKeyBuilder.of(CIPHER_KEY_GENERATOR_CLASS, Type.CLASS)
+                    .documentation(CIPHER_KEY_GENERATOR_CLASS_DOC)
                     .importance(Importance.MEDIUM)
                     .defaultValue(null)
                     .build()

--- a/src/main/java/com/ably/kafka/connect/config/CipherConfig.java
+++ b/src/main/java/com/ably/kafka/connect/config/CipherConfig.java
@@ -1,0 +1,7 @@
+package com.ably.kafka.connect.config;
+
+import org.apache.kafka.connect.sink.SinkRecord;
+
+public interface CipherConfig {
+    String key(SinkRecord record);
+}

--- a/src/main/java/com/ably/kafka/connect/config/DefaultChannelConfig.java
+++ b/src/main/java/com/ably/kafka/connect/config/DefaultChannelConfig.java
@@ -1,20 +1,26 @@
 package com.ably.kafka.connect.config;
 
-import com.ably.kafka.connect.config.ChannelConfig;
-import com.ably.kafka.connect.config.ChannelSinkConnectorConfig;
+import com.ably.kafka.connect.ChannelSinkTask;
 import io.ably.lib.types.AblyException;
 import io.ably.lib.types.ChannelMode;
 import io.ably.lib.types.ChannelOptions;
+import org.apache.kafka.common.utils.Utils;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 import static com.ably.kafka.connect.config.ChannelSinkConnectorConfig.CHANNEL_CONFIG;
+import static com.ably.kafka.connect.config.ChannelSinkConnectorConfig.CIPHER_KEY_CLASS;
 import static com.ably.kafka.connect.config.ChannelSinkConnectorConfig.CLIENT_CHANNEL_CIPHER_KEY;
 import static com.ably.kafka.connect.config.ChannelSinkConnectorConfig.CLIENT_CHANNEL_PARAMS;
 
 public class DefaultChannelConfig implements ChannelConfig {
+    private static final Logger logger = LoggerFactory.getLogger(DefaultChannelConfig.class);
+
     private final ChannelSinkConnectorConfig sinkConnectorConfig;
 
     public DefaultChannelConfig(final ChannelSinkConnectorConfig sinkConnectorConfig) {
@@ -26,11 +32,22 @@ public class DefaultChannelConfig implements ChannelConfig {
         return sinkConnectorConfig.getString(CHANNEL_CONFIG);
     }
 
-    public ChannelOptions getOptions() throws ChannelSinkConnectorConfig.ConfigException {
+    public ChannelOptions getOptions(SinkRecord record) throws ChannelSinkConnectorConfig.ConfigException {
         ChannelOptions channelOptions;
-        final String cipherKey = sinkConnectorConfig.getString(CLIENT_CHANNEL_CIPHER_KEY);
+         String cipherKey = sinkConnectorConfig.getString(CLIENT_CHANNEL_CIPHER_KEY);
+
+        final Object cipherConfigInstance = Utils.newInstance(sinkConnectorConfig.getClass(CIPHER_KEY_CLASS));
+        if (cipherConfigInstance instanceof CipherConfig) {
+            final CipherConfig cipherconfig = (CipherConfig) cipherConfigInstance;
+            cipherKey = cipherconfig.key(record);
+        }else {
+            //ignore for now
+           // throw new ChannelSinkConnectorConfig.ConfigException(String.format("invalid cipher key class %s", CIPHER_KEY_CLASS));
+        }
+
 
         if (cipherKey != null) {
+            logger.info("Using cipher key {}", cipherKey);
             try {
                 channelOptions = ChannelOptions.withCipherKey(cipherKey);
             } catch (AblyException e) {

--- a/src/main/java/com/ably/kafka/connect/config/DefaultChannelConfig.java
+++ b/src/main/java/com/ably/kafka/connect/config/DefaultChannelConfig.java
@@ -1,6 +1,5 @@
 package com.ably.kafka.connect.config;
 
-import com.ably.kafka.connect.ChannelSinkTask;
 import io.ably.lib.types.AblyException;
 import io.ably.lib.types.ChannelMode;
 import io.ably.lib.types.ChannelOptions;
@@ -14,7 +13,7 @@ import java.util.List;
 import java.util.Map;
 
 import static com.ably.kafka.connect.config.ChannelSinkConnectorConfig.CHANNEL_CONFIG;
-import static com.ably.kafka.connect.config.ChannelSinkConnectorConfig.CIPHER_KEY_CLASS;
+import static com.ably.kafka.connect.config.ChannelSinkConnectorConfig.CIPHER_KEY_GENERATOR_CLASS;
 import static com.ably.kafka.connect.config.ChannelSinkConnectorConfig.CLIENT_CHANNEL_CIPHER_KEY;
 import static com.ably.kafka.connect.config.ChannelSinkConnectorConfig.CLIENT_CHANNEL_PARAMS;
 
@@ -56,13 +55,13 @@ public class DefaultChannelConfig implements ChannelConfig {
     private String getCipherKey(SinkRecord record) throws ChannelSinkConnectorConfig.ConfigException {
         final String cipherKey = sinkConnectorConfig.getString(CLIENT_CHANNEL_CIPHER_KEY);
         //Prioritize the cipher key from the configuration class if it exists
-        if (sinkConnectorConfig.getClass(CIPHER_KEY_CLASS) != null) {
-            final Object cipherConfigInstance = Utils.newInstance(sinkConnectorConfig.getClass(CIPHER_KEY_CLASS));
+        if (sinkConnectorConfig.getClass(CIPHER_KEY_GENERATOR_CLASS) != null) {
+            final Object cipherConfigInstance = Utils.newInstance(sinkConnectorConfig.getClass(CIPHER_KEY_GENERATOR_CLASS));
             if (cipherConfigInstance instanceof CipherConfig) {
                 final CipherConfig cipherconfig = (CipherConfig) cipherConfigInstance;
                 return cipherconfig.key(record);
             } else {
-                throw new ChannelSinkConnectorConfig.ConfigException(String.format("invalid cipher key class %s", CIPHER_KEY_CLASS));
+                throw new ChannelSinkConnectorConfig.ConfigException(String.format("invalid cipher key class %s", CIPHER_KEY_GENERATOR_CLASS));
             }
         }
         return cipherKey;

--- a/src/main/java/com/ably/kafka/connect/config/DefaultCipherConfig.java
+++ b/src/main/java/com/ably/kafka/connect/config/DefaultCipherConfig.java
@@ -7,7 +7,8 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Base64;
 
-public class ExampleCipherConfig implements CipherConfig {
+public class DefaultCipherConfig implements CipherConfig {
+    //TODO : Please replace logic in key() if you want to use this as your CipherConfig
     @Override
     public String key(SinkRecord record) {
         try {

--- a/src/main/java/com/ably/kafka/connect/config/ExampleCipherConfig.java
+++ b/src/main/java/com/ably/kafka/connect/config/ExampleCipherConfig.java
@@ -1,0 +1,23 @@
+package com.ably.kafka.connect.config;
+
+import org.apache.kafka.connect.sink.SinkRecord;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Base64;
+
+public class ExampleCipherConfig implements CipherConfig {
+    @Override
+    public String key(SinkRecord record) {
+        try {
+            final MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hash = digest.digest(record.topic().getBytes(StandardCharsets.UTF_8));
+            return Base64.getEncoder().encodeToString(hash);
+        } catch (NoSuchAlgorithmException e) {
+            e.printStackTrace();
+        }
+        return null;
+
+    }
+}

--- a/src/main/java/com/ably/kafka/connect/mapping/DefaultChannelSinkMapping.java
+++ b/src/main/java/com/ably/kafka/connect/mapping/DefaultChannelSinkMapping.java
@@ -23,6 +23,6 @@ public class DefaultChannelSinkMapping implements ChannelSinkMapping {
     public Channel getChannel(@Nonnull SinkRecord sinkRecord, @Nonnull AblyRealtime ablyRealtime) throws AblyException,
             ChannelSinkConnectorConfig.ConfigException {
         final String channelName = configValueEvaluator.evaluate(sinkRecord, channelConfig.getName());
-        return ablyRealtime.channels.get(channelName, channelConfig.getOptions());
+        return ablyRealtime.channels.get(channelName, channelConfig.getOptions(sinkRecord));
     }
 }


### PR DESCRIPTION
Draft PR showcasing individual channel encryption

Add 
`client.channel.cipher.key.class = com.ably.kafka.connect.config.DefaultCipherConfig
`
to your configuration to test this out 

Edit `key()` implemenation  on https://github.com/ably/kafka-connect-ably/blob/a01d33a5cce1f4b9dee0c3d89834aa306071898e/src/main/java/com/ably/kafka/connect/config/DefaultCipherConfig.java for your custom key generation logic based on a record
before build / deployment 