### PR TITLE
Update ably-java version to 1.2.16

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -161,7 +161,7 @@
     <dependency>
       <groupId>io.ably</groupId>
       <artifactId>ably-java</artifactId>
-      <version>1.2.11</version>
+      <version>1.2.16</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Update ably-java to fix a potential vulnerability issue raised with [this internal Slack message](https://ably-real-time.slack.com/archives/C01KS2Q8NN7/p1662720333537259)

> We have identified a vulnerability with the Ably connector. We are working with our tech partners on aggressively fixing the vulnerabilities. Could you please help us fix vulnerabilities as soon as possible? We ran the trivy(https://github.com/aquasecurity/trivy) scanner to identify them.
> PartnerName: ably
> ConnectorName: ably-kafka-connect-ably
> ConnectorVersion: 2.0.1
> VulnerabilityID: CVE-2020-11050
> PkgName: org.java-websocket:Java-WebSocket
> PkgPath: Java-WebSocket-1.4.0.jar
> InstalledVersion: 1.4.0
> FixedVersion: 1.5.0
> Severity: HIGH
> CVSS: 8.1
> Title: java-websocket: WebSocketClient does not perform SSL hostname validation

I checked that our latest library version uses the fixed version of vulnerable dependency