### PR TITLE
Remove jackson-mapper-asl dependency 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -251,14 +251,6 @@
       <scope>test</scope>
     </dependency>
 
-    <!-- https://mvnrepository.com/artifact/org.codehaus.jackson/jackson-mapper-asl -->
-    <dependency>
-      <groupId>org.codehaus.jackson</groupId>
-      <artifactId>jackson-mapper-asl</artifactId>
-      <version>1.9.13</version>
-      <scope>test</scope>
-    </dependency>
-
   </dependencies>
 
 </project>


### PR DESCRIPTION
This PR removes jackson-mapper dependency that has vulnerability.
After all this dependency wasn't necessary and was scoped to tests.

Closes https://github.com/ably/kafka-connect-ably/issues/91