### PR TITLE
Add string key support

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ The advanced properties that can be configured for the connector are:
 | skipOnKeyAbsence                  | Skips the record if channel name or message name is configured with a value containing #{key} but record does not have a valid key.                                                                                                                                         | *Boolean* | false   |
 
 ## Dynamic Channel Configuration
-You can configure your channels dynamically by using `#{topic}` and/or `#{key}` placeholders in some configuration values. If you specify `#{key}` in your value, you must send a UTF-8 encoded string as your key.
+You can configure your channels dynamically by using `#{topic}` and/or `#{key}` placeholders in some configuration values. If you specify `#{key}` in your value, you must either send a UTF-8 encoded byte array or a string as your key value.
 Configurations that are supported:
 * `channel`
   * For example. if you define a channel value with `channel_#{topic}_#{key}` in your configuration, and publish a message to "topic1" with key "key1", the channel will be configured with `channel_topic1_key1` value.

--- a/src/main/java/com/ably/kafka/connect/config/ConfigValueEvaluator.java
+++ b/src/main/java/com/ably/kafka/connect/config/ConfigValueEvaluator.java
@@ -46,13 +46,17 @@ public class ConfigValueEvaluator {
         if (pattern == null) {
             return new Result(false, null);
         }
-        final byte[] key = (byte[]) record.key();
-        String keyString = null;
 
-        //we only want to evalutate UTF-8 encoded strings
-        if(key != null && ByteArrayUtils.isUTF8Encoded(key)) {
-            keyString = new String(key, StandardCharsets.UTF_8);
+        String keyString = null;
+        final Object recordKey = record.key();
+        if (recordKey != null) {
+            if (recordKey instanceof byte[]  && ByteArrayUtils.isUTF8Encoded((byte[]) recordKey)){
+                keyString = new String((byte[]) recordKey, StandardCharsets.UTF_8);
+            }else if (recordKey instanceof String){
+                keyString = (String) recordKey;
+            }
         }
+
         if (keyString == null && pattern.contains(KEY_TOKEN)) {
             if (skippable) {
                 return new Result(true, null);

--- a/src/main/java/com/ably/kafka/connect/config/ConfigValueEvaluator.java
+++ b/src/main/java/com/ably/kafka/connect/config/ConfigValueEvaluator.java
@@ -47,15 +47,7 @@ public class ConfigValueEvaluator {
             return new Result(false, null);
         }
 
-        String keyString = null;
-        final Object recordKey = record.key();
-        if (recordKey != null) {
-            if (recordKey instanceof byte[]  && ByteArrayUtils.isUTF8Encoded((byte[]) recordKey)){
-                keyString = new String((byte[]) recordKey, StandardCharsets.UTF_8);
-            }else if (recordKey instanceof String){
-                keyString = (String) recordKey;
-            }
-        }
+        final String keyString = getKeyString(record);
 
         if (keyString == null && pattern.contains(KEY_TOKEN)) {
             if (skippable) {
@@ -69,5 +61,18 @@ public class ConfigValueEvaluator {
         } else {
             return new Result(false, pattern.replace(TOPIC_TOKEN, record.topic()));
         }
+    }
+
+    private String getKeyString(SinkRecord record) {
+        String keyString = null;
+        final Object recordKey = record.key();
+        if (recordKey != null) {
+            if (recordKey instanceof byte[] && ByteArrayUtils.isUTF8Encoded((byte[]) recordKey)) {
+                keyString = new String((byte[]) recordKey, StandardCharsets.UTF_8);
+            } else if (recordKey instanceof String) {
+                keyString = (String) recordKey;
+            }
+        }
+        return keyString;
     }
 }

--- a/src/main/java/com/ably/kafka/connect/utils/RecordHeaderConversions.java
+++ b/src/main/java/com/ably/kafka/connect/utils/RecordHeaderConversions.java
@@ -39,7 +39,7 @@ public class RecordHeaderConversions {
     @Nullable
     public static MessageExtras toMessageExtras(final SinkRecord record) {
        final Extras.Builder extrasBuilder = new Extras.Builder();
-        final Extras extras = extrasBuilder.key((byte[]) record.key())
+        final Extras extras = extrasBuilder.key(record.key())
             .recordHeaders(record.headers())
             .build();
 
@@ -67,10 +67,18 @@ public class RecordHeaderConversions {
                 return extras;
             }
 
-            Extras.Builder key(byte[] key) {
+            Extras.Builder key(Object key) {
                 if (key != null) {
-                    kafkaExtras().add("key", Base64.getEncoder().encodeToString(key));
-                    topExtrasObject().add(KAFKA_KEY, kafkaExtras());
+                    String keyString = null;
+                    if (key instanceof byte[]) {
+                        keyString = Base64.getEncoder().encodeToString((byte[]) key);
+                    } else if (key instanceof String) {
+                        keyString = (String) key;
+                    }
+                    if (keyString != null) {
+                        kafkaExtras().add("key", keyString);
+                        topExtrasObject().add(KAFKA_KEY, kafkaExtras());
+                    }
                 }
 
                 return this;

--- a/src/main/java/com/ably/kafka/connect/utils/RecordHeaderConversions.java
+++ b/src/main/java/com/ably/kafka/connect/utils/RecordHeaderConversions.java
@@ -42,11 +42,14 @@ public class RecordHeaderConversions {
         JsonUtils.JsonUtilsObject extrasObject = null;
 
         Object pushExtras = null;
-        final byte[] key = (byte[]) record.key();
-        if (key != null) {
+        final Object recordKey = record.key();
+        if (recordKey != null) {
             kafkaExtras = JsonUtils.object();
-            final String keyValue = Base64.getEncoder().encodeToString(key);
-            kafkaExtras.add("key", keyValue);
+            if (recordKey instanceof byte[]){
+                kafkaExtras.add("key", Base64.getEncoder().encodeToString((byte[])recordKey));
+            }else if (recordKey instanceof String){
+                kafkaExtras.add("key", recordKey);
+            }
         }
 
         if (record.headers().isEmpty()){

--- a/src/test/java/com/ably/kafka/connect/ConfigValueEvaluatorTest.java
+++ b/src/test/java/com/ably/kafka/connect/ConfigValueEvaluatorTest.java
@@ -1,6 +1,7 @@
 package com.ably.kafka.connect;
 
 import com.ably.kafka.connect.config.ConfigValueEvaluator;
+import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.junit.jupiter.api.Test;
 
@@ -37,6 +38,19 @@ class ConfigValueEvaluatorTest {
     void testEvaluateKeyIsEvaluated() {
         //given
         SinkRecord sinkRecord = new SinkRecord("greatTopic", 0, null,"greatKey".getBytes(), null, null, 0);
+
+        //when
+        ConfigValueEvaluator.Result result = configValueEvaluator.evaluate(sinkRecord, "#{key}_hello", false);
+
+        //then
+        assertEquals("greatKey_hello", result.getValue());
+    }
+
+    @Test
+    void testEvaluateStringKeyIsEvaluated() {
+        //given
+        final String key = "greatKey";
+        SinkRecord sinkRecord = new SinkRecord("greatTopic", 0, Schema.STRING_SCHEMA, key, null, null, 0);
 
         //when
         ConfigValueEvaluator.Result result = configValueEvaluator.evaluate(sinkRecord, "#{key}_hello", false);

--- a/src/test/java/com/ably/kafka/connect/utils/RecordHeaderConversionsTest.java
+++ b/src/test/java/com/ably/kafka/connect/utils/RecordHeaderConversionsTest.java
@@ -53,6 +53,25 @@ class RecordHeaderConversionsTest {
     }
 
     @Test
+    public void testStringKeyAddsKeyOnKafkaHeader(){
+        //given
+        final String myKey = "my_key";
+        final SinkRecord record = new SinkRecord("topic", 0, Schema.STRING_SCHEMA, myKey, null, null, 0);
+
+        //when
+        final MessageExtras messageExtras = RecordHeaderConversions.toMessageExtras(record);
+
+        //then
+        assertNotNull(messageExtras);
+        final JsonObject jsonObject = messageExtras.asJsonObject();
+        final JsonElement kafkaElement = jsonObject.get("kafka");
+        assertNotNull(kafkaElement);
+        final JsonElement keyElement = kafkaElement.getAsJsonObject().get("key");
+        assertNotNull(keyElement);
+        assertEquals(myKey, keyElement.getAsString());
+    }
+
+    @Test
     public void testPushAddsPushExtrasWithKey() throws IOException {
         //given
         final byte[] keyBytes = "my_key".getBytes();


### PR DESCRIPTION
Adds support for string key for both when creating headers and interpolating for configuration values.

This also removes force cast to byte[] to prevent any crash if key schema is different and instead skips processing the key.

Closes https://github.com/ably/kafka-connect-ably/issues/98