### PR TITLE
Add suspend queue 

### DIFF
--- a/generate_changelog.sh
+++ b/generate_changelog.sh
@@ -1,3 +1,3 @@
 github_changelog_generator -u ably -p kafka-connect-ably since-tag v2.1.1 \
 --output delta.md \
---token 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
+--token <Replace with personal access token>

--- a/generate_changelog.sh
+++ b/generate_changelog.sh
@@ -1,3 +1,0 @@
-github_changelog_generator -u ably -p kafka-connect-ably since-tag v2.1.1 \
---output delta.md \
---token <Replace with personal access token>

--- a/generate_changelog.sh
+++ b/generate_changelog.sh
@@ -1,0 +1,3 @@
+github_changelog_generator -u ably -p kafka-connect-ably since-tag v2.1.1 \
+--output delta.md \
+--token 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

--- a/src/main/java/com/ably/kafka/connect/ChannelSinkTask.java
+++ b/src/main/java/com/ably/kafka/connect/ChannelSinkTask.java
@@ -70,7 +70,14 @@ public class ChannelSinkTask extends SinkTask {
                 ablyClient.publishFrom(suspendRecord);
                 suspendRecord = suspendQueue.dequeue();
             }
-        }else {
+
+            // If connection got into suspended state again add record to the queue, otherwise publish normally
+            if (suspended.get()) {
+                suspendQueue.enqueue(record);
+            } else {
+                ablyClient.publishFrom(record);
+            }
+        } else {
             ablyClient.publishFrom(record);
         }
     }

--- a/src/main/java/com/ably/kafka/connect/ChannelSinkTask.java
+++ b/src/main/java/com/ably/kafka/connect/ChannelSinkTask.java
@@ -34,6 +34,11 @@ public class ChannelSinkTask extends SinkTask {
         this.ablyClientFactory = factory;
     }
 
+    @VisibleForTesting
+    AblyClient getAblyClient() {
+        return ablyClient;
+    }
+
     @Override
     public void start(Map<String, String> settings) {
         logger.info("Starting Ably channel Sink task");

--- a/src/main/java/com/ably/kafka/connect/ChannelSinkTask.java
+++ b/src/main/java/com/ably/kafka/connect/ChannelSinkTask.java
@@ -66,9 +66,10 @@ public class ChannelSinkTask extends SinkTask {
         if (suspended.get()){
             suspendQueue.enqueue(record);
         } else if ((suspendRecord = suspendQueue.dequeue()) != null) {
-            ablyClient.publishFrom(suspendRecord);
-            //re-call for the same record so that (if available) other suspended records are processed first
-            publishSingleRecord(record);
+            while (suspendRecord != null && !suspended.get()){
+                ablyClient.publishFrom(suspendRecord);
+                suspendRecord = suspendQueue.dequeue();
+            }
         }else {
             ablyClient.publishFrom(record);
         }

--- a/src/main/java/com/ably/kafka/connect/SuspendQueue.java
+++ b/src/main/java/com/ably/kafka/connect/SuspendQueue.java
@@ -5,7 +5,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
-Thishis class holds records that are failed to publish after the Ably connection went into suspended state.
+This class holds records that are failed to publish after the Ably connection went into suspended state.
  It will act as an intermediate queue to publish messages rejected between suspension and reconnection
 * */
 public class SuspendQueue<T> {

--- a/src/main/java/com/ably/kafka/connect/SuspendQueue.java
+++ b/src/main/java/com/ably/kafka/connect/SuspendQueue.java
@@ -1,0 +1,23 @@
+package com.ably.kafka.connect;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+Thishis class holds records that are failed to publish after the Ably connection went into suspended state.
+ It will act as an intermediate queue to publish messages rejected between suspension and reconnection
+* */
+public class SuspendQueue<T> {
+    private final List<T> queue;
+
+    SuspendQueue() {
+        queue = new ArrayList<>();
+    }
+
+    synchronized void enqueue(T t) {
+        queue.add(t);
+    }
+
+    synchronized T dequeue() {
+        return queue.isEmpty() ? null : queue.remove(0);
+    }
+}

--- a/src/main/java/com/ably/kafka/connect/SuspendQueue.java
+++ b/src/main/java/com/ably/kafka/connect/SuspendQueue.java
@@ -23,6 +23,10 @@ public class SuspendQueue<T> {
         return queue.isEmpty() ? null : queue.remove(0);
     }
 
+    synchronized boolean isNotEmpty(){
+        return !queue.isEmpty();
+    }
+
     @VisibleForTesting
     synchronized void clear() {
         queue.clear();

--- a/src/main/java/com/ably/kafka/connect/SuspendQueue.java
+++ b/src/main/java/com/ably/kafka/connect/SuspendQueue.java
@@ -1,4 +1,6 @@
 package com.ably.kafka.connect;
+import com.google.common.annotations.VisibleForTesting;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -19,5 +21,10 @@ public class SuspendQueue<T> {
 
     synchronized T dequeue() {
         return queue.isEmpty() ? null : queue.remove(0);
+    }
+
+    @VisibleForTesting
+    synchronized void clear() {
+        queue.clear();
     }
 }

--- a/src/main/java/com/ably/kafka/connect/client/AblyClient.java
+++ b/src/main/java/com/ably/kafka/connect/client/AblyClient.java
@@ -6,9 +6,10 @@ import org.apache.kafka.connect.sink.SinkRecord;
 public interface AblyClient {
     /**
      * Connect to an Ably service.
+     * @param suspensionCallback callback to tell the client whether the connection was suspended.
      * @throws ConnectException if the connection fails
      */
-    void connect() throws ConnectException;
+    void connect(SuspensionCallback suspensionCallback) throws ConnectException;
 
     /**
      * Publish a sink record to Ably.

--- a/src/main/java/com/ably/kafka/connect/client/DefaultAblyClient.java
+++ b/src/main/java/com/ably/kafka/connect/client/DefaultAblyClient.java
@@ -44,7 +44,7 @@ public class DefaultAblyClient implements AblyClient {
     }
 
     @Override
-    public void connect() throws ConnectException {
+    public void connect(SuspensionCallback suspensionCallback) throws ConnectException {
         try {
             realtime = new AblyRealtime(connectorConfig.clientOptions);
             realtime.connection.on(connectionStateChange -> {
@@ -53,6 +53,10 @@ public class DefaultAblyClient implements AblyClient {
                     connectionFailed.set(true);
                 } else if (connectionStateChange.current == ConnectionState.connected) {
                     logger.info("Ably connection successfully established");
+                    suspensionCallback.on(false);
+                } else if (connectionStateChange.current == ConnectionState.suspended) {
+                    logger.info("Ably connection is suspended");
+                    suspensionCallback.on(true);
                 }
             });
 

--- a/src/main/java/com/ably/kafka/connect/client/SuspensionCallback.java
+++ b/src/main/java/com/ably/kafka/connect/client/SuspensionCallback.java
@@ -1,0 +1,8 @@
+package com.ably.kafka.connect.client;
+
+/*
+Interface to be used to communicate connection suspensions
+* */
+public interface SuspensionCallback {
+    void on(boolean suspended);
+}

--- a/src/test/java/com/ably/kafka/connect/ChannelSinkTaskTest.java
+++ b/src/test/java/com/ably/kafka/connect/ChannelSinkTaskTest.java
@@ -38,7 +38,7 @@ public class ChannelSinkTaskTest {
 
     @BeforeEach
     public void setup() throws ChannelSinkConnectorConfig.ConfigException {
-        final FakeClientFactory fakeClientFactory = new FakeClientFactory(3000);
+        final FakeClientFactory fakeClientFactory = new FakeClientFactory(1000);
         SUT = new ChannelSinkTask(fakeClientFactory);
     }
     @AfterEach
@@ -63,8 +63,8 @@ public class ChannelSinkTaskTest {
                 sinkRecords.add(sinkRecord);
 
             }
-            //run for 30 seconds in total
-            Thread.sleep(random.nextInt(300));
+            //run for up to 10 seconds each
+            Thread.sleep(random.nextInt(100));
             SUT.put(sinkRecords);
         }
 

--- a/src/test/java/com/ably/kafka/connect/ChannelSinkTaskTest.java
+++ b/src/test/java/com/ably/kafka/connect/ChannelSinkTaskTest.java
@@ -29,6 +29,8 @@ import org.junit.jupiter.api.TestInfo;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -36,14 +38,18 @@ public class ChannelSinkTaskTest {
     private FakeAblyClient fakeAblyClient;
     private ChannelSinkTask SUT;
 
+    private CountDownLatch countDownLatch;
+
     @BeforeEach
     public void setup() throws ChannelSinkConnectorConfig.ConfigException {
-        final FakeClientFactory fakeClientFactory = new FakeClientFactory(1000);
+        final FakeClientFactory fakeClientFactory = new FakeClientFactory(1000, record -> countDownLatch.countDown());
         SUT = new ChannelSinkTask(fakeClientFactory);
+        countDownLatch = new CountDownLatch(1000);
     }
     @AfterEach
     public void tearDown() throws ChannelSinkConnectorConfig.ConfigException {
         fakeAblyClient.stop();
+        countDownLatch = null;
     }
 
     /**
@@ -63,11 +69,11 @@ public class ChannelSinkTaskTest {
                 sinkRecords.add(sinkRecord);
 
             }
-            //run for up to 10 seconds each
+            //run for up to 100 ms each
             Thread.sleep(random.nextInt(100));
             SUT.put(sinkRecords);
         }
-
+        countDownLatch.await(10, TimeUnit.SECONDS);
         final List<SinkRecord> publishedRecords = fakeAblyClient.getPublishedRecords();
         assertEquals(1000, publishedRecords.size());
 

--- a/src/test/java/com/ably/kafka/connect/SuspendQueueTest.java
+++ b/src/test/java/com/ably/kafka/connect/SuspendQueueTest.java
@@ -1,0 +1,86 @@
+package com.ably.kafka.connect;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Random;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SuspendQueueTest {
+    private SuspendQueue<String> suspendQueue = new SuspendQueue<>();
+
+    @AfterEach
+    void afterEach(){
+       suspendQueue.clear();
+    }
+
+    @Test
+    public void testAddRemoveItemsReceivedInCorrectOrderWhenAddedSequentially(){
+        for (int i = 0; i < 20; i++) {
+            suspendQueue.enqueue("item:"+i);
+        }
+        for (int i = 0; i < 20; i++) {
+            assertEquals("item:"+i, suspendQueue.dequeue());
+        }
+        assertNull(suspendQueue.dequeue());
+    }
+
+ /*   add to the queue concurrently and read sequentially ensuring the right amount of items are received and also make
+    sure that all items were receieved*/
+    @Test
+    public void testAddRemoveItemsReceivedInCorrectSizeWhenAddedConcurrently() throws InterruptedException {
+        final Set<String> addSet = ConcurrentHashMap.newKeySet(40);
+        final ExecutorService executorService = Executors.newFixedThreadPool(2);
+        final Random random = new Random();
+        final CountDownLatch latch = new CountDownLatch(2);
+        final Runnable firstAddRunnable = () -> {
+            for (int i = 0; i < 20; i++) {
+                final String toAdd = "item from first: " + i;
+                addSet.add(toAdd);
+                suspendQueue.enqueue(toAdd);
+                try {
+                    Thread.sleep(random.nextInt(100));
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+            latch.countDown();
+        };
+
+        final Runnable secondAddRunnable = () -> {
+            for (int i = 0; i < 20; i++) {
+                final String toAdd = "item from second:" + i;
+                addSet.add(toAdd);
+                suspendQueue.enqueue(toAdd);
+                try {
+                    Thread.sleep(random.nextInt(100));
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+            latch.countDown();
+        };
+
+        executorService.execute(firstAddRunnable);
+        executorService.execute(secondAddRunnable);
+        latch.await();
+        int count = 0;
+        String polled = null;
+        while ((polled = suspendQueue.dequeue()) != null) {
+            count++;
+            assertTrue(addSet.contains(polled));
+            addSet.remove(polled);
+        }
+        assertEquals(40, count);
+        executorService.shutdown();
+    }
+
+}

--- a/src/test/java/com/ably/kafka/connect/fakes/FakeAblyClient.java
+++ b/src/test/java/com/ably/kafka/connect/fakes/FakeAblyClient.java
@@ -10,12 +10,17 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class FakeAblyClient implements AblyClient {
+    public interface Listener{
+        void onPublish(SinkRecord record);
+    }
     final long randomTimeBound;
     private final List<SinkRecord> publishedRecords = new ArrayList<>();
     private RandomConnectionStateChanger randomConnectionStateChanger;
+    private final Listener publishListener;
 
-    public FakeAblyClient(long randomTimeBound) {
+    public FakeAblyClient(long randomTimeBound, Listener publishListener) {
         this.randomTimeBound = randomTimeBound;
+        this.publishListener = publishListener;
     }
 
     @Override
@@ -33,6 +38,7 @@ public class FakeAblyClient implements AblyClient {
     @Override
     public void publishFrom(SinkRecord record) throws ConnectException {
         publishedRecords.add(record);
+        publishListener.onPublish(record);
     }
 
     public List<SinkRecord> getPublishedRecords() {

--- a/src/test/java/com/ably/kafka/connect/fakes/FakeAblyClient.java
+++ b/src/test/java/com/ably/kafka/connect/fakes/FakeAblyClient.java
@@ -24,9 +24,10 @@ public class FakeAblyClient implements AblyClient {
            if (state == ConnectionState.connected){
                suspensionCallback.on(false);
            } else if (state == ConnectionState.suspended) {
-               suspensionCallback.on(false);
+               suspensionCallback.on(true);
            }
        });
+       new Thread(randomConnectionStateChanger).start();
     }
 
     @Override

--- a/src/test/java/com/ably/kafka/connect/fakes/FakeAblyClient.java
+++ b/src/test/java/com/ably/kafka/connect/fakes/FakeAblyClient.java
@@ -1,0 +1,46 @@
+package com.ably.kafka.connect.fakes;
+
+import com.ably.kafka.connect.client.AblyClient;
+import com.ably.kafka.connect.client.SuspensionCallback;
+import io.ably.lib.realtime.ConnectionState;
+import org.apache.kafka.connect.errors.ConnectException;
+import org.apache.kafka.connect.sink.SinkRecord;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class FakeAblyClient implements AblyClient {
+    final long randomTimeBound;
+    private final List<SinkRecord> publishedRecords = new ArrayList<>();
+    private RandomConnectionStateChanger randomConnectionStateChanger;
+
+    public FakeAblyClient(long randomTimeBound) {
+        this.randomTimeBound = randomTimeBound;
+    }
+
+    @Override
+    public void connect(SuspensionCallback suspensionCallback) throws ConnectException {
+       randomConnectionStateChanger = new RandomConnectionStateChanger(randomTimeBound, state -> {
+           if (state == ConnectionState.connected){
+               suspensionCallback.on(false);
+           } else if (state == ConnectionState.suspended) {
+               suspensionCallback.on(false);
+           }
+       });
+    }
+
+    @Override
+    public void publishFrom(SinkRecord record) throws ConnectException {
+        publishedRecords.add(record);
+    }
+
+    public List<SinkRecord> getPublishedRecords() {
+        return publishedRecords;
+    }
+
+    @Override
+    public void stop() {
+       publishedRecords.clear();
+    }
+
+}

--- a/src/test/java/com/ably/kafka/connect/fakes/FakeClientFactory.java
+++ b/src/test/java/com/ably/kafka/connect/fakes/FakeClientFactory.java
@@ -8,13 +8,15 @@ import java.util.Map;
 
 public class FakeClientFactory implements AblyClientFactory {
     private final long randomTimeBound;
+    private final FakeAblyClient.Listener publishListener;
 
-    public FakeClientFactory(long randomTimeBound) {
+    public FakeClientFactory(long randomTimeBound, FakeAblyClient.Listener publishListener) {
         this.randomTimeBound = randomTimeBound;
+        this.publishListener = publishListener;
     }
 
     @Override
     public AblyClient create(Map<String, String> settings) throws ChannelSinkConnectorConfig.ConfigException {
-        return new FakeAblyClient(randomTimeBound);
+        return new FakeAblyClient(randomTimeBound, publishListener);
     }
 }

--- a/src/test/java/com/ably/kafka/connect/fakes/FakeClientFactory.java
+++ b/src/test/java/com/ably/kafka/connect/fakes/FakeClientFactory.java
@@ -1,0 +1,20 @@
+package com.ably.kafka.connect.fakes;
+
+import com.ably.kafka.connect.client.AblyClient;
+import com.ably.kafka.connect.client.AblyClientFactory;
+import com.ably.kafka.connect.config.ChannelSinkConnectorConfig;
+
+import java.util.Map;
+
+public class FakeClientFactory implements AblyClientFactory {
+    private final long randomTimeBound;
+
+    public FakeClientFactory(long randomTimeBound) {
+        this.randomTimeBound = randomTimeBound;
+    }
+
+    @Override
+    public AblyClient create(Map<String, String> settings) throws ChannelSinkConnectorConfig.ConfigException {
+        return new FakeAblyClient(randomTimeBound);
+    }
+}

--- a/src/test/java/com/ably/kafka/connect/fakes/RandomConnectionStateChanger.java
+++ b/src/test/java/com/ably/kafka/connect/fakes/RandomConnectionStateChanger.java
@@ -32,7 +32,7 @@ class RandomConnectionStateChanger implements Runnable {
                 lastState = ConnectionState.suspended;
             }
 
-            final long sleepTime = random.nextLong() % randomTimeBound;
+            final long sleepTime = Math.abs(random.nextLong()) % randomTimeBound;
             try {
                 Thread.sleep(sleepTime);
             } catch (InterruptedException e) {

--- a/src/test/java/com/ably/kafka/connect/fakes/RandomConnectionStateChanger.java
+++ b/src/test/java/com/ably/kafka/connect/fakes/RandomConnectionStateChanger.java
@@ -1,0 +1,43 @@
+package com.ably.kafka.connect.fakes;
+
+import io.ably.lib.realtime.ConnectionState;
+import java.util.Random;
+
+//randomly changes state
+class RandomConnectionStateChanger implements Runnable {
+    private ConnectionState lastState;
+
+    interface Callback {
+        void onStateChange(ConnectionState state);
+    }
+
+    private final long randomTimeBound;
+    private final Callback callback;
+    private final Random random;
+
+    RandomConnectionStateChanger(long randomTimeBound, Callback callback) {
+        this.randomTimeBound = randomTimeBound;
+        this.callback = callback;
+        random = new Random();
+    }
+
+    @Override
+    public void run() {
+        while (true) {
+            if (lastState == null || lastState == ConnectionState.suspended) {
+                callback.onStateChange(ConnectionState.connected);
+                lastState = ConnectionState.connected;
+            } else {
+                callback.onStateChange(ConnectionState.suspended);
+                lastState = ConnectionState.suspended;
+            }
+
+            final long sleepTime = random.nextLong() % randomTimeBound;
+            try {
+                Thread.sleep(sleepTime);
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Add an intermediate queue to re-publish messages that were failed because of connection going into suspended state.

Fixes https://github.com/ably/kafka-connect-ably/issues/106
