### PR TITLE
Bump ably java to 1.2.27

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -161,7 +161,7 @@
     <dependency>
       <groupId>io.ably</groupId>
       <artifactId>ably-java</artifactId>
-      <version>1.2.25</version>
+      <version>1.2.27</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
This change bumps the ably-java version to 1.2.27 which includes a fix for connections entering the suspended state if they disconnect after being connected for a long period.