### PR TITLE
Fix Docker build errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM maven:3-openjdk-11 AS build
+FROM maven:3-openjdk-16 AS build
 
 WORKDIR /usr/src/app
 

--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,9 @@
       <plugin>
         <artifactId>maven-javadoc-plugin</artifactId>
         <version>3.3.0</version>
+        <configuration>
+          <doclint>all,-missing</doclint>
+        </configuration>
       </plugin>
       <plugin>
         <groupId>io.confluent</groupId>

--- a/src/main/java/com/ably/kafka/connect/mapping/ChannelSinkMapping.java
+++ b/src/main/java/com/ably/kafka/connect/mapping/ChannelSinkMapping.java
@@ -13,7 +13,6 @@ public interface ChannelSinkMapping {
      * Create a new Ably channel based on the sink record.
      * @param sinkRecord
      * @return
-     * @throws AblyException
      */
     String getChannelName(@Nonnull SinkRecord sinkRecord);
 }


### PR DESCRIPTION
This gets the build instructions in the README working again.

This removes errors about missing javadoc comments, as it seems we've fallen way behind on this anyway. If the team want to restore that lint check, a PR will be needed to add the missing docs and re-enable it.

Also updating the Docker build base image to match the min java requirement, as compilation within the container now fails as it's still running Java 11.

Fixing the one legit javadoc error on `ChannelSinkMapping`, as this can no-longer throw `AblyException` since the signature change and no `AblyRealtime` client is provided anymore.