### PR TITLE
Update to Confluent Platform 7.4.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ COPY src src/
 
 RUN mvn clean package
 
-FROM confluentinc/cp-kafka-connect:6.0.2-1-ubi8
+FROM confluentinc/cp-kafka-connect:7.4.0-2-ubi8
 
 COPY --from=build /usr/src/app/target/kafka-connect-target/usr/share/kafka-connect /plugins/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM maven:3-openjdk-11 AS build
+FROM maven:3-openjdk-16 AS build
 
 WORKDIR /usr/src/app
 

--- a/Dockerfile_development
+++ b/Dockerfile_development
@@ -1,4 +1,4 @@
-FROM confluentinc/cp-kafka-connect:6.0.2-1-ubi8
+FROM confluentinc/cp-kafka-connect:7.4.0-2-ubi8
 COPY target/kafka-connect-target/usr/share/kafka-connect /plugins/
 
 ADD bin/docker-entrypoint.sh /bin/docker-entrypoint.sh

--- a/docker-compose-distributed.yml
+++ b/docker-compose-distributed.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:5.4.10-1-ubi8
+    image: confluentinc/cp-zookeeper:7.4.0-2-ubi8
     networks:
       kafka_distributed_network:
     environment:
@@ -11,7 +11,7 @@ services:
     #  - '2181:2181'
 
   kafka:
-    image: confluentinc/cp-server:5.4.10-1-ubi8
+    image: confluentinc/cp-server:7.4.0-2-ubi8
     hostname: kafka
     container_name: kafka
     networks:
@@ -37,7 +37,7 @@ services:
       KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
 
   schema-registry:
-    image: confluentinc/cp-schema-registry:5.4.10-1-ubi8
+    image: confluentinc/cp-schema-registry:7.4.0-2-ubi8
     networks:
       kafka_distributed_network:
         aliases:
@@ -49,7 +49,7 @@ services:
       SCHEMA_REGISTRY_HOST_NAME: schema-registry
 
   control-center:
-    image: confluentinc/cp-enterprise-control-center:5.4.10-1-ubi8
+    image: confluentinc/cp-enterprise-control-center:7.4.0-2-ubi8
     networks:
       kafka_distributed_network:
         aliases:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:5.4.10-1-ubi8
+    image: confluentinc/cp-zookeeper:7.4.0-2-ubi8
     container_name: zookeper
     networks:
       kafka_network:
@@ -12,8 +12,7 @@ services:
     #  - '2181:2181'
 
   kafka:
-#    image: confluentinc/cp-server:5.4.10-1-ubi8
-    image: confluentinc/cp-enterprise-kafka:5.4.0
+    image: confluentinc/cp-enterprise-kafka:7.4.0-2-ubi8
     hostname: kafka
     container_name: kafka
     networks:
@@ -39,7 +38,7 @@ services:
       KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
 
   schema-registry:
-    image: confluentinc/cp-schema-registry:5.4.10-1-ubi8
+    image: confluentinc/cp-schema-registry:7.4.0-2-ubi8
     container_name: schema-registry
     networks:
       kafka_network:
@@ -52,7 +51,7 @@ services:
       SCHEMA_REGISTRY_HOST_NAME: schema-registry
 
   control-center:
-    image: confluentinc/cp-enterprise-control-center:5.4.10-1-ubi8
+    image: confluentinc/cp-enterprise-control-center:7.4.0-2-ubi8
     container_name: control-center
     networks:
       kafka_network:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
     environment:
       ZOOKEEPER_CLIENT_PORT: 2181
       zk_id: '1'
+      ZOOKEEPER_LOG4J_ROOT_LOGLEVEL: INFO
     # ports:
     #  - '2181:2181'
 
@@ -36,6 +37,7 @@ services:
       KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092, EXTERNAL_LISTENER://localhost:29092
       KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT, EXTERNAL_LISTENER:PLAINTEXT
       KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+      KAFKA_LOG4J_ROOT_LOGLEVEL: INFO
 
   schema-registry:
     image: confluentinc/cp-schema-registry:7.4.0-2-ubi8
@@ -47,8 +49,10 @@ services:
     ports:
        - '8081:8081'
     environment:
-      SCHEMA_REGISTRY_KAFKASTORE_CONNECTION_URL: 'zookeeper:2181'
+      SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS: 'PLAINTEXT://kafka:9092'
+      SCHEMA_REGISTRY_LISTENERS: 'http://schema-registry:8081'
       SCHEMA_REGISTRY_HOST_NAME: schema-registry
+      SCHEMA_REGISTRY_LOG4J_ROOT_LOGLEVEL: INFO
 
   control-center:
     image: confluentinc/cp-enterprise-control-center:7.4.0-2-ubi8
@@ -70,6 +74,7 @@ services:
       CONTROL_CENTER_REPLICATION_FACTOR: 1
       CONTROL_CENTER_CONFLUENT_CONTROLCENTER_SCHEMA_REGISTRY_URL: 'http://schema-registry:8081'
       CONTROL_CENTER_SCHEMA_REGISTRY_URL: 'http://schema-registry:8081'
+      CONTROL_CENTER_LOG4J_ROOT_LOGLEVEL: INFO
 
   connector:
     container_name: connector
@@ -87,6 +92,7 @@ services:
       SUSPEND: ${SUSPEND:-n}
       CONNECT_REST_PORT: 8083
       CONNECT_REST_ADVERTISED_HOST_NAME: connector
+      CONNECT_LOG4J_ROOT_LOGLEVEL: INFO
     networks:
       kafka_network:
         aliases:

--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,9 @@
       <plugin>
         <artifactId>maven-javadoc-plugin</artifactId>
         <version>3.3.0</version>
+        <configuration>
+          <doclint>all,-missing</doclint>
+        </configuration>
       </plugin>
       <plugin>
         <groupId>io.confluent</groupId>

--- a/src/main/java/com/ably/kafka/connect/ChannelSinkTask.java
+++ b/src/main/java/com/ably/kafka/connect/ChannelSinkTask.java
@@ -18,6 +18,7 @@ import org.apache.kafka.connect.sink.SinkTask;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Map;
 import java.util.concurrent.BlockingQueue;
@@ -80,7 +81,7 @@ public class ChannelSinkTask extends SinkTask {
         if(records.size() > 0) {
             logger.debug("SinkTask put - Num records: " + records.size());
 
-            Lists.partition(records.stream().toList(), this.maxBufferLimit).forEach(batch -> {
+            Lists.partition(new ArrayList<>(records), this.maxBufferLimit).forEach(batch -> {
                 this.executor.execute(new BatchProcessingThread(batch, this.ablyClient));
             });
         }

--- a/src/main/java/com/ably/kafka/connect/mapping/ChannelSinkMapping.java
+++ b/src/main/java/com/ably/kafka/connect/mapping/ChannelSinkMapping.java
@@ -13,7 +13,6 @@ public interface ChannelSinkMapping {
      * Create a new Ably channel based on the sink record.
      * @param sinkRecord
      * @return
-     * @throws AblyException
      */
     String getChannelName(@Nonnull SinkRecord sinkRecord);
 }


### PR DESCRIPTION
This updates the docker images we're using to the latest version of Confluent Platform.

The 6.0 release we used previously comes with Java 8, so the latest code wouldn't work.

This release distributes with Java 11. Later versions are supported but you have to modify the image yourself to do this. There's one change needed to `ChannelSinkTask` to be Java 11 compatible included here.

