### PR TITLE
Support multiple tasks

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -70,7 +70,7 @@ services:
     environment:
       CONTROL_CENTER_BOOTSTRAP_SERVERS: 'kafka:9092'
       CONTROL_CENTER_ZOOKEEPER_CONNECT: 'zookeeper:2181'
-      CONTROL_CENTER_CONNECT_CLUSTER: 'connect:8083'
+      CONTROL_CENTER_CONNECT_CLUSTER: 'connector:8083'
       CONTROL_CENTER_REPLICATION_FACTOR: 1
       CONTROL_CENTER_CONFLUENT_CONTROLCENTER_SCHEMA_REGISTRY_URL: 'http://schema-registry:8081'
       CONTROL_CENTER_SCHEMA_REGISTRY_URL: 'http://schema-registry:8081'
@@ -87,10 +87,12 @@ services:
       - ./config:/config
     ports:
       - 5005:5005
+      - 8083:8083
     environment:
       PORT: 5005
       SUSPEND: ${SUSPEND:-n}
       CONNECT_REST_PORT: 8083
+      CONNECT_LISTENERS: 'http://:8083'
       CONNECT_REST_ADVERTISED_HOST_NAME: connector
       CONNECT_LOG4J_ROOT_LOGLEVEL: INFO
     networks:

--- a/src/main/java/com/ably/kafka/connect/ChannelSinkConnector.java
+++ b/src/main/java/com/ably/kafka/connect/ChannelSinkConnector.java
@@ -39,8 +39,7 @@ public class ChannelSinkConnector extends SinkConnector {
 
     @Override
     public List<Map<String, String>> taskConfigs(int maxTasks) {
-        //TODO: Add multi-partition publisher
-        return Collections.singletonList(this.settings);
+        return Collections.nCopies(maxTasks, this.settings);
     }
 
     @Override


### PR DESCRIPTION
Closes #138 

Setting `max.tasks` to any value >= 1 previously made no difference to the number of tasks running, you'd always just get a single task. This is because we only ever returned a single config instance, no-matter how many tasks were being requested as a maximum by the Connect framework. More details in ticket #138 
