### PR TITLE
feat!: stringify and flatten Kafka headers in extras

### DIFF
--- a/src/main/java/com/ably/kafka/connect/utils/RecordHeaderConversions.java
+++ b/src/main/java/com/ably/kafka/connect/utils/RecordHeaderConversions.java
@@ -46,9 +46,9 @@ public class RecordHeaderConversions {
         return extras.toMessageExtras();
     }
 
-    /*
-    Wrapper class representing extras and is to be used to simplify building of extras object
-    * */
+    /**
+     * Wrapper class representing extras and is to be used to simplify building of extras object
+     */
     private static class Extras {
 
         private JsonUtils.JsonUtilsObject kafkaObject;
@@ -95,9 +95,15 @@ public class RecordHeaderConversions {
             private void buildFromHeaders(Headers headers) {
                 for (Header header : headers) {
                     if (header.key().equals(PUSH_HEADER)) {
-                        extras.pushExtrasValue = stringifyHeaderValueIfPrimitive(header);
+                        // We don't stringify push header value, it is special header, that end up as a nested JSON object
+                        // @see `Extras#buildPushPayload`
+                        extras.pushExtrasValue = header.value();
                     } else {
-                        headersObject().add(header.key(), stringifyHeaderValueIfPrimitive(header));
+                        // Kafka automatically deserialises headers. Because Kafka doesn't know about what types
+                        // were originally, headers just get deserialised to the most obvious type. So that means
+                        // numeric strings end up as a numbers. There’s a problem with Realtime whereby large numbers
+                        // in headers breaks things. That's why we always stringify header value
+                        headersObject().add(header.key(), String.valueOf(header.value()));
                     }
                 }
 
@@ -179,17 +185,5 @@ public class RecordHeaderConversions {
             }
             return null;
         }
-
-        /**
-         * Stringify header value if it is primitive.
-         */
-        private static Object stringifyHeaderValueIfPrimitive(Header header) {
-            if (header.schema() != null && header.schema().type().isPrimitive()) {
-                return String.valueOf(header.value());
-            } else {
-                return header.value();
-            }
-        }
-
     }
 }

--- a/src/main/java/com/ably/kafka/connect/utils/RecordHeaderConversions.java
+++ b/src/main/java/com/ably/kafka/connect/utils/RecordHeaderConversions.java
@@ -102,7 +102,7 @@ public class RecordHeaderConversions {
                 }
 
                 if (extras.headersObject != null) {
-                    kafkaExtras().add(HEADERS_KEY, extras.headersObject);
+                    topExtrasObject().add(HEADERS_KEY, extras.headersObject);
                 }
 
                 buildPushExtras();

--- a/src/main/java/com/ably/kafka/connect/utils/RecordHeaderConversions.java
+++ b/src/main/java/com/ably/kafka/connect/utils/RecordHeaderConversions.java
@@ -95,9 +95,9 @@ public class RecordHeaderConversions {
             private void buildFromHeaders(Headers headers) {
                 for (Header header : headers) {
                     if (header.key().equals(PUSH_HEADER)) {
-                        extras.pushExtrasValue = header.value();
+                        extras.pushExtrasValue = stringifyHeaderValueIfPrimitive(header);
                     } else {
-                        headersObject().add(header.key(), header.value());
+                        headersObject().add(header.key(), stringifyHeaderValueIfPrimitive(header));
                     }
                 }
 
@@ -178,6 +178,17 @@ public class RecordHeaderConversions {
                 return new MessageExtras(topObject.toJson());
             }
             return null;
+        }
+
+        /**
+         * Stringify header value if it is primitive.
+         */
+        private static Object stringifyHeaderValueIfPrimitive(Header header) {
+            if (header.schema() != null && header.schema().type().isPrimitive()) {
+                return String.valueOf(header.value());
+            } else {
+                return header.value();
+            }
         }
 
     }

--- a/src/test/java/com/ably/kafka/connect/MessageConversionTest.java
+++ b/src/test/java/com/ably/kafka/connect/MessageConversionTest.java
@@ -119,8 +119,7 @@ class MessageConversionTest {
         final MessageExtras messageExtras = MessageConverter.toAblyMessage("name", record).extras;
 
         //then
-        final JsonObject receivedObject = messageExtras.asJsonObject().get("kafka").getAsJsonObject();
-        final JsonObject receivedHeaders = receivedObject.get("headers").getAsJsonObject();
+        final JsonObject receivedHeaders = messageExtras.asJsonObject().get("headers").getAsJsonObject();
         assertEquals(receivedHeaders.get("key1").getAsString(), "value1");
         assertEquals(receivedHeaders.get("key2").getAsString(), "value2");
     }


### PR DESCRIPTION
This PR fix two problems with Kafka headers:

* When the message reaches our Kafka Connector that contains headers, Kafka automatically deserialises those headers. Because Kafka doesn't know about what types things were originally, things just get deserialised to the most obvious type. So that means numeric strings end up as a numbers. There’s a problem with Realtime whereby large numbers in headers breaks things.
* headers shouldn’t be in `extras.kafka.headers` but instead simply in `extras.headers` - the former screws around with other things.



