### PR TITLE
fix: commit topic partitions end offsets

### DIFF
--- a/src/main/java/com/ably/kafka/connect/offset/OffsetRegistryService.java
+++ b/src/main/java/com/ably/kafka/connect/offset/OffsetRegistryService.java
@@ -78,7 +78,8 @@ public class OffsetRegistryService implements OffsetRegistry {
             TopicPartition topicPartition = entry.getKey();
 
             if (topicPartitionToOffsetMap.containsKey(topicPartition)) {
-                committedOffsets.put(topicPartition, new OffsetAndMetadata(topicPartitionToOffsetMap.get(topicPartition)));
+                Long endOffset = topicPartitionToOffsetMap.get(topicPartition) + 1;
+                committedOffsets.put(topicPartition, new OffsetAndMetadata(endOffset));
             }
         }
 

--- a/src/test/java/com/ably/kafka/connect/AblyBatchClientTest.java
+++ b/src/test/java/com/ably/kafka/connect/AblyBatchClientTest.java
@@ -141,8 +141,8 @@ public class AblyBatchClientTest {
             )
         );
         assertEquals(Map.of(
-            new TopicPartition("topic1", 0), new OffsetAndMetadata(1),
-            new TopicPartition("topic1", 1), new OffsetAndMetadata(4)
+            new TopicPartition("topic1", 0), new OffsetAndMetadata(2),
+            new TopicPartition("topic1", 1), new OffsetAndMetadata(5)
         ), offsets);
     }
 
@@ -334,8 +334,8 @@ public class AblyBatchClientTest {
         // Offset registry *should* have been updated for both partitions, as we've DLQ'ed failures
         assertEquals(
             Map.of(
-                new TopicPartition("topic1", 0), new OffsetAndMetadata(0),
-                new TopicPartition("topic1", 1), new OffsetAndMetadata(1)
+                new TopicPartition("topic1", 0), new OffsetAndMetadata(1),
+                new TopicPartition("topic1", 1), new OffsetAndMetadata(2)
             ), registry.updateOffsets(
                 Map.of(
                     new TopicPartition("topic1", 0), new OffsetAndMetadata(20),

--- a/src/test/java/com/ably/kafka/connect/offset/OffsetRegistryServiceTest.java
+++ b/src/test/java/com/ably/kafka/connect/offset/OffsetRegistryServiceTest.java
@@ -105,8 +105,8 @@ public class OffsetRegistryServiceTest {
         Map<TopicPartition, OffsetAndMetadata> result = offsetRegistryService.updateOffsets(preCommitOffsets);
 
         Map<TopicPartition, OffsetAndMetadata> expectedResult = new HashMap<>();
-        expectedResult.put(new TopicPartition("topic1", 0), new OffsetAndMetadata(3L));
-        expectedResult.put(new TopicPartition("topic1", 1), new OffsetAndMetadata(2L));
+        expectedResult.put(new TopicPartition("topic1", 0), new OffsetAndMetadata(4L));
+        expectedResult.put(new TopicPartition("topic1", 1), new OffsetAndMetadata(3L));
 
         assertEquals(result, expectedResult);
     }


### PR DESCRIPTION
Set topic partitions offsets to the end of logs.

Issue:  https://github.com/ably/kafka-connect-ably/issues/193