### PR TITLE
fix: upgrade msgpack-core to 0.9.11 to address security vulnerability

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -174,7 +174,7 @@
     <dependency>
       <groupId>org.msgpack</groupId>
       <artifactId>msgpack-core</artifactId>
-      <version>0.9.1</version>
+      <version>0.9.11</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Resolves CVE-2026-21452, a denial of service vulnerability in msgpack-java versions prior to 0.9.11.