### PR TITLE
bump: ably-java to 1.6.0

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -5,6 +5,8 @@ on:
   push:
     branches:
       - main
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+*'
 
 jobs:
   build:
@@ -32,12 +34,21 @@ jobs:
           role-to-assume: arn:aws:iam::${{ secrets.ABLY_AWS_ACCOUNT_ID_SDK}}:role/ably-sdk-builds-kafka-connect-ably
           role-session-name: "${{ github.run_id }}-${{ github.run_number }}"
 
+      - name: Read artifacts names
+        id: artifacts
+        run: |
+          MSK_ARCHIVE=$(basename "$(find build/distributions/msk -name '*.zip' -type f | head -n 1)")
+          CONFLUENT_ARCHIVE=$(basename "$(find build/distributions/confluent -name '*.zip' -type f | head -n 1)")
+          echo "msk_archive=${MSK_ARCHIVE}" >> $GITHUB_OUTPUT
+          echo "confluent_archive=${CONFLUENT_ARCHIVE}" >> $GITHUB_OUTPUT
+
       - name: Upload Confluent ZIP archive
         uses: ably/sdk-upload-action@v2
         with:
           sourcePath: build/distributions/confluent
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           artifactName: kafka-connect-ably
+          landingPagePath: ${{ steps.artifacts.outputs.confluent_archive }}
 
       - name: Upload MSK Plugin ZIP archive
         uses: ably/sdk-upload-action@v2
@@ -45,3 +56,5 @@ jobs:
           sourcePath: build/distributions/msk
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           artifactName: kafka-connect-ably-msk-plugin
+          landingPagePath: ${{ steps.artifacts.outputs.msk_archive }}
+

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,5 @@
+import java.time.LocalDate
+
 plugins {
     java
     `maven-publish`
@@ -139,10 +141,10 @@ val confluentArchive by tasks.registering(Zip::class) {
                 "logo": "assets/ably.png"
               },
               "support": {
-                "provider_name": "Ably",
+                "summary": "This connector is <a href=\"https://ably.com/support\">supported by Ably</a>",
                 "url": "https://ably.com/support",
                 "logo": "assets/ably.png",
-                "summary": "This connector is supported by Ably"
+                "provider_name": "Ably"
               },
               "tags": ["Ably", "realtime", "kafka-connect-ably"],
               "features": {
@@ -152,6 +154,13 @@ val confluentArchive by tasks.registering(Zip::class) {
                 "kafka_connect_api": true
               },
               "documentation_url": "https://github.com/ably/kafka-connect-ably",
+              "source_url": "https://github.com/ably/kafka-connect-ably",
+              "license": [ {
+                "name": "The Apache License, Version 2.0",
+                "url": "https://www.apache.org/licenses/LICENSE-2.0"
+              } ],
+              "docker_image": { },
+              "release_date": "${LocalDate.now()}",
               "component_types": ["sink"]
             }
         """.trimIndent())

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,10 +2,10 @@
 # Core versions
 kafka = "3.9.1"
 kafka-scala = "2.13"
-confluent = "7.9.2"
+confluent = "7.9.5"
 
 # Library versions
-ably = "1.2.54"
+ably = "1.6.0"
 guava = "33.4.0-jre"
 gson = "2.11.0"
 msgpack = "0.9.11"


### PR DESCRIPTION
Also add `release_date` to manifest and point to deployments to the archive