### PR TITLE
docs: update plugin download URLs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,4 +43,8 @@ This library uses [semantic versioning](http://semver.org/). For each release, t
 5. Once the PR is approved, merge it into `main`
 6. Add a tag and push to origin - e.g.: `git tag v1.2.3 && git push origin v1.2.3`
 7. Create the release on Github including populating the release notes
-8. Notify the product team that a new ZIP file needs to be sent to Confluent Hub, which can be downloaded at the following URL (replacing the version number with the version number built, available once [the workflow](.github/workflows/integration-test.yml) has finished executing on `main`): https://sdk.ably.com/builds/ably/kafka-connect-ably/main/kafka-connect-ably/ably-kafka-connect-ably-1.2.3.zip
+8. Notify the product team that a new ZIP file needs to be sent to Confluent Hub, which can be downloaded at 
+the following URL (replacing the version number with the version number built, available once
+[the workflow](.github/workflows/integration-test.yml) has finished executing on pushed tag, v1.2.3 in the example): 
+https://sdk.ably.com/builds/ably/kafka-connect-ably/tag/v{VERSION}/kafka-connect-ably/kafka-connect-ably-{VERSION}.zip
+Where `{VERSION}` is the version number.

--- a/examples/msk_connect/README.md
+++ b/examples/msk_connect/README.md
@@ -16,7 +16,7 @@ A quick summary of what's needed to connect MSK to Ably:
 If you're an existing MSK user and would like to forward data to Ably, the high-level steps are:
 
 * Obtain the latest plugin zip, either by:
-  * Downloading it [here](https://sdk.ably.com/builds/ably/kafka-connect-ably/main/kafka-connect-ably-msk-plugin/kafka-connect-ably-4.1.2-bin.zip)
+  * Downloading it [here](https://sdk.ably.com/builds/ably/kafka-connect-ably/tag/v{VERSION}/kafka-connect-ably-msk-plugin/kafka-connect-ably-{VERSION}-bin.zip)
   * Checking out this repo and running `./gradlew clean assemble`, the zip will be at `build/distributions/msk`
 * Put the plugin zip somewhere your MSK Connector can access it, e.g. an S3 bucket that you control
   * Note: MSK Connect will only download plugin binaries from S3 buckets in the same region as the connector, so


### PR DESCRIPTION
We used to use a URL with `main/`, but the current implementation overwrites the artifact on each push to main. This makes it risky to share the link and can lead to non-deterministic results. As quick fix now we changed links to `tag/v{TAG}/...`