### PR TITLE
ci: GHA workflow security cleanup

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -17,6 +17,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -8,12 +8,15 @@ on:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+*'
 
+permissions: {}
+
 jobs:
   build:
     runs-on: ubuntu-latest
     permissions:
-      deployments: write
-      id-token: write
+      contents: read    # checkout the repository
+      deployments: write # ably/sdk-upload-action publishes preview artifacts as GitHub deployments
+      id-token: write   # aws-actions/configure-aws-credentials uses OIDC to assume an AWS role
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -19,21 +19,21 @@ jobs:
       id-token: write   # aws-actions/configure-aws-credentials uses OIDC to assume an AWS role
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           java-version: "17"
           distribution: "temurin"
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@48b5f213c81028ace310571dc5ec0fbbca0b2947 # v4
       - name: Build with Gradle
         run: ./gradlew build --no-daemon --stacktrace
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
         with:
           aws-region: eu-west-2
           role-to-assume: arn:aws:iam::${{ secrets.ABLY_AWS_ACCOUNT_ID_SDK}}:role/ably-sdk-builds-kafka-connect-ably
@@ -48,7 +48,7 @@ jobs:
           echo "confluent_archive=${CONFLUENT_ARCHIVE}" >> $GITHUB_OUTPUT
 
       - name: Upload Confluent ZIP archive
-        uses: ably/sdk-upload-action@v2
+        uses: ably/sdk-upload-action@4e694297f208b72b5a9f6b1248a1556f19f821d6 # v2
         with:
           sourcePath: build/distributions/confluent
           githubToken: ${{ secrets.GITHUB_TOKEN }}
@@ -56,7 +56,7 @@ jobs:
           landingPagePath: ${{ steps.artifacts.outputs.confluent_archive }}
 
       - name: Upload MSK Plugin ZIP archive
-        uses: ably/sdk-upload-action@v2
+        uses: ably/sdk-upload-action@4e694297f208b72b5a9f6b1248a1556f19f821d6 # v2
         with:
           sourcePath: build/distributions/msk
           githubToken: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Routine hygiene pass over the GitHub Actions workflow in this repo, addressing findings from a workflow security audit. Changes are split into three commits, one per finding type:

- Disable credential persistence on the actions/checkout step so the default GITHUB_TOKEN is not left in the local git config after checkout.
- Scope the workflow's permissions explicitly: top-level permissions: {}, with the build job granted only the GITHUB_TOKEN scopes it actually needs (contents: read for checkout,
deployments: write for ably/sdk-upload-action, id-token: write for AWS OIDC).
- Pin all third-party actions to commit SHAs (with the tag preserved as a comment) so an upstream tag move can't silently change what runs in CI.

No behavioural changes intended - the workflow runs the same checks against the same inputs.